### PR TITLE
Adding in Device.connected_to context manager and Peer.sustain

### DIFF
--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -1373,6 +1373,13 @@ class HCI_Error(ProtocolError):
         super().__init__(error_code, 'hci', HCI_Constant.error_name(error_code))
 
 
+class HCI_StatusError(ProtocolError):
+    def __init__(self, response):
+        super().__init__(response.status,
+                error_namespace=HCI_Command.command_name(response.command_opcode),
+                error_name=HCI_Constant.status_name(response.status))
+
+
 # -----------------------------------------------------------------------------
 # Generic HCI object
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
* Device.connected_to connects to a peer as a context manager.
* The peer is disconnected when leaving the context
* Will perform discovery automatically on connecting, if requested
* Added HCI_StatusError that can be raised when a HCI Command Status
  event is received that doesn't show "PENDING" as status
* Added Connection.sustain to wait for a timeout or disconnect
* Peer.sustain also maps to Connectin.sustain
* Updated battery_client.py to use .connected_to and .sustain