### PR TITLE
Add subscribe and unsubscribe commands to console.py

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -123,6 +123,9 @@ class Peer:
     async def subscribe(self, characteristic, subscriber=None):
         return await self.gatt_client.subscribe(characteristic, subscriber)
 
+    async def unsubscribe(self, characteristic, subscriber=None):
+        return await self.gatt_client.unsubscribe(characteristic, subscriber)
+
     async def read_value(self, attribute):
         return await self.gatt_client.read_value(attribute)
 

--- a/tests/gatt_test.py
+++ b/tests/gatt_test.py
@@ -440,6 +440,10 @@ async def test_subscribe_notify():
     assert(c1._last_update is not None)
     assert(c1._last_update[1] == characteristic1.value)
 
+    assert(peer.gatt_client.notification_subscribers[c1.handle])
+    await peer.unsubscribe(c1)
+    assert(c1.handle not in peer.gatt_client.notification_subscribers)
+
     c2._last_update = None
 
     def on_c2_update(value):
@@ -454,6 +458,10 @@ async def test_subscribe_notify():
     await async_barrier()
     assert(c2._last_update is not None)
     assert(c2._last_update[1] == characteristic2.value)
+
+    assert(on_c2_update in peer.gatt_client.indication_subscribers[c2.handle])
+    await peer.unsubscribe(c2, on_c2_update)
+    assert(on_c2_update not in peer.gatt_client.indication_subscribers[c2.handle])
 
     c3._last_update = None
 
@@ -472,6 +480,12 @@ async def test_subscribe_notify():
     await async_barrier()
     assert(c3._last_update is not None)
     assert(c3._last_update[1] == characteristic3.value)
+
+    assert(peer.gatt_client.notification_subscribers[c3.handle])
+    assert(peer.gatt_client.indication_subscribers[c3.handle])
+    await peer.unsubscribe(c3)
+    assert(c3.handle not in peer.gatt_client.notification_subscribers)
+    assert(c3.handle not in peer.gatt_client.indication_subscribers)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Subscribe command will enable notify or indicate events from the
characteristic, depending on supported characteristic properties, and
print recevied values to the output window.

Unsubscribe will stop notify or indicate events.

Rename find_attribute() to find_characteristic() and return a
characteristic for a set of UUIDS, a characteristic for an attribute
handle, or None.

Print read and received values has a hex string.

Add an unsubscribe implementation to gatt_client.py. Reset the CCCD bits
to 0x0000 and remove all subscribers for a characteristic, since no more
notify or indicates events will be comming.