### PR TITLE
[doc] Add section on `lsusb` to quick start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,44 @@ The complete [list of Examples](/docs/mkdocs/src/examples/index.md), and what th
 
 There are also a set of [Apps and Tools](docs/mkdocs/src/apps_and_tools/index.md) that show the utility of Bumble.
 
+### Detecting Bluetooth Interfaces
+
+Bumble is easiest to use with a dedicated USB dongle.
+This is because internal Bluetooth interfaces tend to be locked down by the operating system.
+To detect which Bluetooth dongles are connected, use `lsusb`.
+
+#### Installing lsusb
+
+On Mac: `brew install lsusb`
+On Linux: `sudo apt-get install usbutils`
+
+#### Using lsusb
+
+```
+$ lsusb
+Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+Bus 003 Device 014: ID 0b05:17cb ASUSTek Computer, Inc. Broadcom BCM20702A0 Bluetooth
+```
+
+Note the device id for the Bluetooth interface in this case is `0b05:17cb`.
+
+#### Passing usb:id to example
+
+When running the examples, `usb:0` can be passed to use the first available Bluetooth interface.
+Alternatively, the explicit interface identifier returned from `lsusb` may be used:
+
+```
+$ python3 ./apps/scan.py usb:0b05:17cb
+<<< connecting to HCI...
+<<< connected
+>>> 0F:02:72:7B:1D:1A [RANDOM](non-resolvable):
+  RSSI: -73 ████████████▊
+  [Complete List of 16-bit Service Class UUIDs]: UUID-16:FD6F
+  [Service Data]: service=UUID-16:FD6F, data=c43c0cc51d1b8a5c57dcf61069f8f50ba9f7302a
+
+  ...
+```
+
 ## License
 
 Licensed under the [Apache 2.0](LICENSE) License.


### PR DESCRIPTION
Added section to quick start guide going over the basics of detecting available Bluetooth dongles and passing the appropriate interface identifier to the examples.