### PR TITLE
improve USB device detection logic

### DIFF
--- a/apps/usb_probe.py
+++ b/apps/usb_probe.py
@@ -185,37 +185,43 @@ def main(verbose):
             if device_is_bluetooth_hci:
                 bumble_transport_names.append(f'usb:{bluetooth_device_count - 1}')
 
-            serial_number_collision = False
-            if device_id in devices:
-                for device_serial in devices[device_id]:
-                    if device_serial == device.getSerialNumber():
-                        serial_number_collision = True
-
-            if device_id not in devices:
-                bumble_transport_names.append(basic_transport_name)
-            else:
-                bumble_transport_names.append(f'{basic_transport_name}#{len(devices[device_id])}')
-
-            if device.getSerialNumber() and not serial_number_collision:
-                bumble_transport_names.append(f'{basic_transport_name}/{device.getSerialNumber()}')
 
             print(color(f'ID {device.getVendorID():04X}:{device.getProductID():04X}', fg=fg_color, bg=bg_color))
-            if bumble_transport_names:
-                print(color('  Bumble Transport Names:', 'blue'), ' or '.join(color(x, 'cyan' if device_is_bluetooth_hci else 'red') for x in bumble_transport_names))
             print(color('  Bus/Device:            ', 'green'), f'{device.getBusNumber():03}/{device.getDeviceAddress():03}')
-            if device.getSerialNumber():
-                print(color('  Serial:                ', 'green'), device.getSerialNumber())
             print(color('  Class:                 ', 'green'), device_class_string)
             print(color('  Subclass/Protocol:     ', 'green'), device_subclass_string)
-            print(color('  Manufacturer:          ', 'green'), device.getManufacturer())
-            print(color('  Product:               ', 'green'), device.getProduct())
 
-            if verbose:
-                show_device_details(device)
+            try:
+                serial_number_collision = False
+                if device_id in devices:
+                    for device_serial in devices[device_id]:
+                        if device_serial == device.getSerialNumber():
+                            serial_number_collision = True
 
-            print()
+                if device_id not in devices:
+                    bumble_transport_names.append(basic_transport_name)
+                else:
+                    bumble_transport_names.append(f'{basic_transport_name}#{len(devices[device_id])}')
 
-            devices.setdefault(device_id, []).append(device.getSerialNumber())
+                if device.getSerialNumber() and not serial_number_collision:
+                    bumble_transport_names.append(f'{basic_transport_name}/{device.getSerialNumber()}')
+
+                if bumble_transport_names:
+                    print(color('  Bumble Transport Names:', 'blue'), ' or '.join(color(x, 'cyan' if device_is_bluetooth_hci else 'red') for x in bumble_transport_names))
+                if device.getSerialNumber():
+                    print(color('  Serial:                ', 'green'), device.getSerialNumber())
+                print(color('  Manufacturer:          ', 'green'), device.getManufacturer())
+                print(color('  Product:               ', 'green'), device.getProduct())
+
+                if verbose:
+                    show_device_details(device)
+
+                print()
+
+                devices.setdefault(device_id, []).append(device.getSerialNumber())
+
+            except usb1.USBError as e:
+                print(color(f'  {e}', 'red'))
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -310,10 +310,14 @@ async def open_usb_transport(spec):
                 device_index = int(device_index_str)
 
             for device in context.getDeviceIterator(skip_on_error=True):
+                try:
+                    device_serial_number = device.getSerialNumber()
+                except usb1.USBError:
+                    device_serial_number = None
                 if (
                     device.getVendorID() == int(vendor_id, 16) and
                     device.getProductID() == int(product_id, 16) and
-                    (serial_number is None or device.getSerialNumber() == serial_number)
+                    (serial_number is None or serial_number == device_serial_number)
                 ):
                     if device_index == 0:
                         found = device

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -45,6 +45,10 @@ nav:
     - HCI Bridge: apps_and_tools/hci_bridge.md
     - Golden Gate Bridge: apps_and_tools/gg_bridge.md
     - Show: apps_and_tools/show.md
+    - GATT Dump: apps_and_tools/gatt_dump.md
+    - Pair: apps_and_tools/pair.md
+    - Unbond: apps_and_tools/unbond.md
+    - USB Probe: apps_and_tools/usb_probe.md
   - Hardware:
     - Overview: hardware/index.md
   - Platforms:

--- a/docs/mkdocs/src/apps_and_tools/usb_probe.md
+++ b/docs/mkdocs/src/apps_and_tools/usb_probe.md
@@ -13,15 +13,27 @@ type of device (there's no way to tell).
 
 ## Usage
 
-This command line tool takes no arguments.
+This command line tool may be invoked with no arguments, or with `--verbose`
+for extra details.
 When installed from PyPI, run as
 ```
 $ bumble-usb-probe
 ```
 
+or, for extra details, with the `--verbose` argument
+```
+$ bumble-usb-probe --v
+```
+
 When running from the source distribution:
 ```
 $ python3 apps/usb-probe.py
+```
+
+or 
+
+```
+$ python3 apps/usb-probe.py --verbose
 ```
 
 !!! example

--- a/docs/mkdocs/src/transports/usb.md
+++ b/docs/mkdocs/src/transports/usb.md
@@ -5,6 +5,7 @@ The USB transport interfaces with a local Bluetooth USB dongle.
 
 ## Moniker
 The moniker for a USB transport is either:
+
   * `usb:<index>`
   * `usb:<vendor>:<product>`
   * `usb:<vendor>:<product>/<serial-number>`
@@ -15,6 +16,10 @@ In the `usb:<index>` form, matching devices are the ones supporting Bluetooth HC
 In the `usb:<vendor>:<product>#<index>` form, matching devices are the ones with the specified `<vendor>` and `<product>` identification.
 
 `<vendor>` and `<product>` are a vendor ID and product ID in hexadecimal.
+
+In addition, if the moniker ends with the symbol "!", the device will be used in "forced" mode:
+the first USB interface of the device will be used, regardless of the interface class/subclass.
+This may be useful for some devices that use a custom class/subclass but may nonetheless work as-is.
 
 !!! examples
     `usb:04b4:f901`  
@@ -28,6 +33,10 @@ In the `usb:<vendor>:<product>#<index>` form, matching devices are the ones with
 
     `usb:04b4:f901/#1`
     The second USB dongle with `<vendor>` equal to `04b4` and `<product>` equal to `f901`
+
+    `usb:0B05:17CB!`
+    The BT USB dongle vendor=0B05 and product=17CB, in "forced" mode.
+
 
 ## Alternative
 The library includes two different implementations of the USB transport, implemented using different python bindings for `libusb`.


### PR DESCRIPTION
Some USB devices don't use compliant descriptors for their interfaces. This PR allows forcing the auto-detection logic to use those devices nonetheless.
Also included is better way to detect compliant devices (devices where the BT class is set on the interfaces but not on the whole device), so they can be used as `usb:<index>` rather than requiring an explicit `usb:<vendor>:<product>`.
Finally, a `--verbose` option is added to `usb_probe.py` that will list all the endpoints for each enumerated device.
