### PR TITLE
use arg-less main() functions in all scripts

### DIFF
--- a/apps/show.py
+++ b/apps/show.py
@@ -90,7 +90,7 @@ class SnoopPacketReader:
 @click.command()
 @click.option('--format', type=click.Choice(['h4', 'snoop']), default='h4', help='Format of the input file')
 @click.argument('filename')
-def show(format, filename):
+def main(format, filename):
     input = open(filename, 'rb')
     if format == 'h4':
         packet_reader = PacketReader(input)
@@ -117,4 +117,4 @@ def show(format, filename):
 
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':
-    show()
+    main()

--- a/apps/usb_probe.py
+++ b/apps/usb_probe.py
@@ -29,6 +29,7 @@
 import os
 import logging
 import sys
+import click
 import usb1
 from colors import color
 
@@ -149,6 +150,8 @@ def is_bluetooth_hci(device):
 
 
 # -----------------------------------------------------------------------------
+@click.command()
+@click.option('--verbose', is_flag=True, default=False, help='Print more details')
 def main(verbose):
     logging.basicConfig(level = os.environ.get('BUMBLE_LOGLEVEL', 'WARNING').upper())
 
@@ -233,9 +236,4 @@ def main(verbose):
 
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':
-    if len(sys.argv) == 2 and sys.argv[1] == '--verbose':
-        verbose = True
-    else:
-        verbose = False
-
-    main(verbose)
+    main()


### PR DESCRIPTION
When installing a script with setup.cfg, the script needs to have a `main` function with no arguments (at least on Windows).
