### PR TITLE
support with_response on adapters

### DIFF
--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -346,8 +346,11 @@ class CharacteristicAdapter:
     async def read_decoded_value(self):
         return self.decode_value(await self.wrapped_characteristic.read_value())
 
-    async def write_decoded_value(self, value):
-        return await self.wrapped_characteristic.write_value(self.encode_value(value))
+    async def write_decoded_value(self, value, with_response=False):
+        return await self.wrapped_characteristic.write_value(
+            self.encode_value(value),
+            with_response
+        )
 
     def encode_value(self, value):
         return value

--- a/bumble/gatt_client.py
+++ b/bumble/gatt_client.py
@@ -184,8 +184,8 @@ class Client:
         # Wait until we can send (only one pending command at a time for the connection)
         response = None
         async with self.request_semaphore:
-            assert(self.pending_request is None)
-            assert(self.pending_response is None)
+            assert self.pending_request is None
+            assert self.pending_response is None
 
             # Create a future value to hold the eventual response
             self.pending_response = asyncio.get_running_loop().create_future()

--- a/tests/gatt_test.py
+++ b/tests/gatt_test.py
@@ -164,6 +164,17 @@ async def test_characteristic_encoding():
     await async_barrier()
     assert characteristic.value == bytes([124])
 
+    v = await cp.read_value()
+    assert v == 124
+    await cp.write_value(125, with_response=True)
+    await async_barrier()
+    assert characteristic.value == bytes([125])
+
+    cd = DelegatedCharacteristicAdapter(c, encode=lambda x: bytes([x // 2]))
+    await cd.write_value(100, with_response=True)
+    await async_barrier()
+    assert characteristic.value == bytes([50])
+
     last_change = None
 
     def on_change(value):


### PR DESCRIPTION
When calling `write_value(..., with_response=True)` on a proxy with a type adapter, the `with_response` parameter has to be supported.