### PR TITLE
use the correct constants as previously renamed

### DIFF
--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -262,7 +262,7 @@ class Characteristic(Attribute):
 
     def get_descriptor(self, descriptor_type):
         for descriptor in self.descriptors:
-            if descriptor.uuid == descriptor_type:
+            if descriptor.type == descriptor_type:
                 return descriptor
 
     def __str__(self):

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -3970,7 +3970,7 @@ class HCI_LE_Advertising_Report_Event(HCI_LE_Meta_Event):
         super().__init__(self.subevent_code, parameters)
 
     def __str__(self):
-        reports = '\n'.join([report.to_string('  ') for report in self.reports])
+        reports = '\n'.join([f'{i}:\n{report.to_string("  ")}' for i, report in enumerate(self.reports)])
         return f'{color(self.subevent_name(self.subevent_code), "magenta")}:\n{reports}'
 
 
@@ -4187,7 +4187,7 @@ class HCI_LE_Extended_Advertising_Report_Event(HCI_LE_Meta_Event):
         super().__init__(self.subevent_code, parameters)
 
     def __str__(self):
-        reports = '\n'.join([report.to_string('  ') for report in self.reports])
+        reports = '\n'.join([f'{i}:\n{report.to_string("  ")}' for i, report in enumerate(self.reports)])
         return f'{color(self.subevent_name(self.subevent_code), "magenta")}:\n{reports}'
 
 

--- a/examples/keyboard.py
+++ b/examples/keyboard.py
@@ -34,8 +34,8 @@ from bumble.gatt import (
     Characteristic,
     CharacteristicValue,
     GATT_DEVICE_INFORMATION_SERVICE,
-    GATT_DEVICE_HUMAN_INTERFACE_DEVICE_SERVICE,
-    GATT_DEVICE_BATTERY_SERVICE,
+    GATT_HUMAN_INTERFACE_DEVICE_SERVICE,
+    GATT_BATTERY_SERVICE,
     GATT_BATTERY_LEVEL_CHARACTERISTIC,
     GATT_MANUFACTURER_NAME_STRING_CHARACTERISTIC,
     GATT_REPORT_CHARACTERISTIC,
@@ -126,8 +126,8 @@ async def keyboard_host(device, peer_address):
     connection = await device.connect(peer_address)
     await connection.pair()
     peer = Peer(connection)
-    await peer.discover_service(GATT_DEVICE_HUMAN_INTERFACE_DEVICE_SERVICE)
-    hid_services = peer.get_services_by_uuid(GATT_DEVICE_HUMAN_INTERFACE_DEVICE_SERVICE)
+    await peer.discover_service(GATT_HUMAN_INTERFACE_DEVICE_SERVICE)
+    hid_services = peer.get_services_by_uuid(GATT_HUMAN_INTERFACE_DEVICE_SERVICE)
     if not hid_services:
         print(color('!!! No HID service', 'red'))
         return
@@ -221,7 +221,7 @@ async def keyboard_device(device, command):
             ]
         ),
         Service(
-            GATT_DEVICE_HUMAN_INTERFACE_DEVICE_SERVICE,
+            GATT_HUMAN_INTERFACE_DEVICE_SERVICE,
             [
                 Characteristic(
                     GATT_PROTOCOL_MODE_CHARACTERISTIC,
@@ -252,7 +252,7 @@ async def keyboard_device(device, command):
             ]
         ),
         Service(
-            GATT_DEVICE_BATTERY_SERVICE,
+            GATT_BATTERY_SERVICE,
             [
                 Characteristic(
                     GATT_BATTERY_LEVEL_CHARACTERISTIC,
@@ -273,7 +273,7 @@ async def keyboard_device(device, command):
         AdvertisingData([
             (AdvertisingData.COMPLETE_LOCAL_NAME, bytes('Bumble Keyboard', 'utf-8')),
             (AdvertisingData.INCOMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS,
-                bytes(GATT_DEVICE_HUMAN_INTERFACE_DEVICE_SERVICE)),
+                bytes(GATT_HUMAN_INTERFACE_DEVICE_SERVICE)),
             (AdvertisingData.APPEARANCE, struct.pack('<H', 0x03C1)),
             (AdvertisingData.FLAGS, bytes([0x05]))
         ])


### PR DESCRIPTION
Some constants had typos and were renamed in a previous commit, but not all examples that used those constants renamed their imports.