### PR TITLE
fix classic connection event filtering

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1212,15 +1212,16 @@ class Device(CompositeEventEmitter):
         if type(peer_address) is str:
             try:
                 peer_address = Address(peer_address)
+                if transport == BT_BR_EDR_TRANSPORT:
+                    peer_address.address_type = Address.PUBLIC_DEVICE_ADDRESS
             except ValueError:
                 # If the address is not parsable, assume it is a name instead
                 logger.debug('looking for peer by name')
                 peer_address = await self.find_peer_by_name(peer_address, transport)  # TODO: timeout
-
-        # All BR/EDR addresses should be public addresses
-        if transport == BT_BR_EDR_TRANSPORT and peer_address.address_type != Address.PUBLIC_DEVICE_ADDRESS:
-            peer_address = peer_address.clone()
-            peer_address.address_type = Address.PUBLIC_DEVICE_ADDRESS
+        else:
+            # All BR/EDR addresses should be public addresses
+            if transport == BT_BR_EDR_TRANSPORT and peer_address.address_type != Address.PUBLIC_DEVICE_ADDRESS:
+                raise ValueError('BR/EDR addresses must be PUBLIC')
 
         def on_connection(connection):
             if transport == BT_LE_TRANSPORT or (

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1217,6 +1217,11 @@ class Device(CompositeEventEmitter):
                 logger.debug('looking for peer by name')
                 peer_address = await self.find_peer_by_name(peer_address, transport)  # TODO: timeout
 
+        # All BR/EDR addresses should be public addresses
+        if transport == BT_BR_EDR_TRANSPORT and peer_address.address_type != Address.PUBLIC_DEVICE_ADDRESS:
+            peer_address = peer_address.clone()
+            peer_address.address_type = Address.PUBLIC_DEVICE_ADDRESS
+
         def on_connection(connection):
             if transport == BT_LE_TRANSPORT or (
                 # match BR/EDR connection event against peer address

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1211,9 +1211,7 @@ class Device(CompositeEventEmitter):
 
         if type(peer_address) is str:
             try:
-                peer_address = Address(peer_address)
-                if transport == BT_BR_EDR_TRANSPORT:
-                    peer_address.address_type = Address.PUBLIC_DEVICE_ADDRESS
+                peer_address = Address.from_string_for_transport(peer_address, transport)
             except ValueError:
                 # If the address is not parsable, assume it is a name instead
                 logger.debug('looking for peer by name')

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -1667,6 +1667,14 @@ class Address:
         return name_or_number(Address.ADDRESS_TYPE_NAMES, address_type)
 
     @staticmethod
+    def from_string_for_transport(string, transport):
+        if transport == BT_BR_EDR_TRANSPORT:
+            address_type = Address.PUBLIC_DEVICE_ADDRESS
+        else:
+            address_type = Address.RANDOM_DEVICE_ADDRESS
+        return Address(string, address_type)
+
+    @staticmethod
     def parse_address(data, offset):
         # Fix the type to a default value. This is used for parsing type-less Classic addresses
         return Address.parse_address_with_type(data, offset, Address.PUBLIC_DEVICE_ADDRESS)

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -1706,6 +1706,9 @@ class Address:
 
         self.address_type = address_type
 
+    def clone(self):
+        return Address(self.address_bytes, self.address_type)
+
     @property
     def is_public(self):
         return self.address_type == self.PUBLIC_DEVICE_ADDRESS or self.address_type == self.PUBLIC_IDENTITY_ADDRESS


### PR DESCRIPTION
A previous commit broke `await device.connect()` for Classic connections when an address was passed that wasn't correctly set to PUBLIC. Since BR/EDR addresses can't be random or private, this PR forces the address type used in the comparison when filtering for connections in the event handler.