### PR TITLE
Add prefer_notify option to gatt_client subscribe()

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -294,8 +294,8 @@ class Peer:
     async def discover_attributes(self):
         return await self.gatt_client.discover_attributes()
 
-    async def subscribe(self, characteristic, subscriber=None):
-        return await self.gatt_client.subscribe(characteristic, subscriber)
+    async def subscribe(self, characteristic, subscriber=None, prefer_notify=True):
+        return await self.gatt_client.subscribe(characteristic, subscriber, prefer_notify)
 
     async def unsubscribe(self, characteristic, subscriber=None):
         return await self.gatt_client.unsubscribe(characteristic, subscriber)


### PR DESCRIPTION
If characteristic supports Notify and Indicate, the prefer_notify option will subscribe with Notify if True or Indicate if False.

If characteristic only supports one property, Notify or Indicate, that mode will be selected, regardless of the prefer_notify setting.

Tested with a characteristic that supports both Notify and Indicate and verified that prefer_notify sets the desired mode.