### PR TITLE
address: add public information to the stringified value

### DIFF
--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -1753,7 +1753,10 @@ class Address:
         '''
         String representation of the address, MSB first
         '''
-        return ':'.join([f'{x:02X}' for x in reversed(self.address_bytes)])
+        str = ':'.join([f'{x:02X}' for x in reversed(self.address_bytes)])
+        if not self.is_public:
+            return str
+        return str + '/P'
 
 
 # -----------------------------------------------------------------------------

--- a/tests/hci_test.py
+++ b/tests/hci_test.py
@@ -59,7 +59,7 @@ def test_HCI_LE_Connection_Complete_Event():
 
 # -----------------------------------------------------------------------------
 def test_HCI_LE_Advertising_Report_Event():
-    address = Address('00:11:22:33:44:55')
+    address = Address('00:11:22:33:44:55/P')
     report = HCI_LE_Advertising_Report_Event.Report(
         HCI_LE_Advertising_Report_Event.Report.FIELDS,
         event_type   = HCI_LE_Advertising_Report_Event.ADV_IND,


### PR DESCRIPTION
This affect the way security keys are stored. For instance the same key can be used both as public and random, and it need to be stored separately one from each other.