### PR TITLE
lower the number of test cases for l2cap in order to speed up the test

### DIFF
--- a/tests/l2cap_test.py
+++ b/tests/l2cap_test.py
@@ -85,8 +85,8 @@ async def setup_connection():
     await two_devices.devices[0].connect(two_devices.devices[1].random_address)
 
     # Check the post conditions
-    assert(two_devices.connections[0] is not None)
-    assert(two_devices.connections[1] is not None)
+    assert two_devices.connections[0] is not None
+    assert two_devices.connections[1] is not None
 
     return two_devices
 
@@ -94,31 +94,31 @@ async def setup_connection():
 # -----------------------------------------------------------------------------
 def test_helpers():
     psm = L2CAP_Connection_Request.serialize_psm(0x01)
-    assert(psm == bytes([0x01, 0x00]))
+    assert psm == bytes([0x01, 0x00])
 
     psm = L2CAP_Connection_Request.serialize_psm(0x1023)
-    assert(psm == bytes([0x23, 0x10]))
+    assert psm == bytes([0x23, 0x10])
 
     psm = L2CAP_Connection_Request.serialize_psm(0x242311)
-    assert(psm == bytes([0x11, 0x23, 0x24]))
+    assert psm == bytes([0x11, 0x23, 0x24])
 
     (offset, psm) = L2CAP_Connection_Request.parse_psm(bytes([0x00, 0x01, 0x00, 0x44]), 1)
-    assert(offset == 3)
-    assert(psm == 0x01)
+    assert offset == 3
+    assert psm == 0x01
 
     (offset, psm) = L2CAP_Connection_Request.parse_psm(bytes([0x00, 0x23, 0x10, 0x44]), 1)
-    assert(offset == 3)
-    assert(psm == 0x1023)
+    assert offset == 3
+    assert psm == 0x1023
 
     (offset, psm) = L2CAP_Connection_Request.parse_psm(bytes([0x00, 0x11, 0x23, 0x24, 0x44]), 1)
-    assert(offset == 4)
-    assert(psm == 0x242311)
+    assert offset == 4
+    assert psm == 0x242311
 
     rq = L2CAP_Connection_Request(psm = 0x01, source_cid = 0x44)
     brq = bytes(rq)
     srq = L2CAP_Connection_Request.from_bytes(brq)
-    assert(srq.psm == rq.psm)
-    assert(srq.source_cid == rq.source_cid)
+    assert srq.psm == rq.psm
+    assert srq.source_cid == rq.source_cid
 
 
 # -----------------------------------------------------------------------------
@@ -170,12 +170,12 @@ async def test_basic_connection():
     l2cap_channel.on('close', lambda: on_close(0, None))
     incoming_channel.on('close', lambda: on_close(1, closed_event))
     await l2cap_channel.disconnect()
-    assert(closed == [True, True])
+    assert closed == [True, True]
     await closed_event.wait()
 
     sent_bytes = b''.join(messages)
     received_bytes = b''.join(received)
-    assert(sent_bytes == received_bytes)
+    assert sent_bytes == received_bytes
 
 
 # -----------------------------------------------------------------------------
@@ -201,7 +201,7 @@ async def transfer_payload(max_credits, mtu, mps):
 
     messages = [
         bytes([1, 2, 3, 4, 5, 6, 7]) * x
-        for x in (3, 10, 100, 500, 789)
+        for x in (3, 10, 100, 789)
     ]
     for message in messages:
         l2cap_channel.write(message)
@@ -214,14 +214,14 @@ async def transfer_payload(max_credits, mtu, mps):
 
     sent_bytes = b''.join(messages)
     received_bytes = b''.join(received)
-    assert(sent_bytes == received_bytes)
+    assert sent_bytes == received_bytes
 
 
 @pytest.mark.asyncio
 async def test_transfer():
     for max_credits in (1, 10, 100, 10000):
-        for mtu in (23, 24, 25, 26, 50, 200, 255, 256, 1000):
-            for mps in (23, 24, 25, 26, 50, 200, 255, 256, 1000):
+        for mtu in (50, 255, 256, 1000):
+            for mps in (50, 255, 256, 1000):
                 # print(max_credits, mtu, mps)
                 await transfer_payload(max_credits, mtu, mps)
 
@@ -267,8 +267,8 @@ async def test_bidirectional_transfer():
     message_bytes = b''.join(messages)
     client_received_bytes = b''.join(client_received)
     server_received_bytes = b''.join(server_received)
-    assert(client_received_bytes == message_bytes)
-    assert(server_received_bytes == message_bytes)
+    assert client_received_bytes == message_bytes
+    assert server_received_bytes == message_bytes
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The test was using unnecessarily many combinations, causing the test to take sometimes more than a minute. 
This more limited set should be enough.
(also, fix the assert syntax, parentheses are not needed)