### PR TITLE
Fix for 'Host' object has no attribute 'add_listener'

### DIFF
--- a/apps/console.py
+++ b/apps/console.py
@@ -443,7 +443,10 @@ class ConsoleApp:
         # Discover all services, characteristics and descriptors
         self.append_to_output('discovering services...')
         await self.connected_peer.discover_services()
-        self.append_to_output(f'found {len(self.connected_peer.services)} services, discovering charateristics...')
+        self.append_to_output(
+            f'found {len(self.connected_peer.services)} services,'
+            ' discovering characteristics...'
+        )
         await self.connected_peer.discover_characteristics()
         self.append_to_output('found characteristics, discovering descriptors...')
         for service in self.connected_peer.services:

--- a/bumble/l2cap.py
+++ b/bumble/l2cap.py
@@ -1224,7 +1224,7 @@ class ChannelManager:
             self._host.remove_listener('disconnection', self.on_disconnection)
         self._host = host
         if host is not None:
-            host.add_listener('disconnection', self.on_disconnection)
+            host.on('disconnection', self.on_disconnection)
 
     def find_channel(self, connection_handle, cid):
         if connection_channels := self.channels.get(connection_handle):


### PR DESCRIPTION
Pyee's add_listener() method was not added until release 9.0.0. Bumble's setup.cfg specifies a minimum pyee version of 8.2.2.

Remove the call to add_listener() in l2cap.py. If the add_listener() API is prefered over the on(), another solution would be to bump the pyee version requirement.