### PR TITLE
Fix test failures

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Get history and tags for SCM versioning to work
       run: |
         git fetch --prune --unshallow
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*      
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
@@ -30,9 +30,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ".[build,test,development,documentation]"
-    - name: Test with pytest
+    - name: Test
       run: |
-        pytest
+        invoke test
     - name: Build
       run: |
         inv build

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -1110,7 +1110,7 @@ class Session:
         self.manager.on_pairing(self, peer_address, keys)
 
     def on_pairing_failure(self, reason):
-        logger.warn(f'pairing failure ({error_name(reason)})')
+        logger.warning(f'pairing failure ({error_name(reason)})')
 
         if self.completed:
             return

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ build =
 test =
     pytest >= 6.2
     pytest-asyncio >= 0.17
+    pytest-html >= 3.2.0
     coverage >= 6.4
 development =
     invoke >= 1.4

--- a/tasks.py
+++ b/tasks.py
@@ -53,7 +53,7 @@ test_tasks = Collection()
 ns.add_collection(test_tasks, name="test")
 
 @task
-def test(ctx, filter=None, junit=False, install=False):
+def test(ctx, filter=None, junit=False, install=False, html=False):
     # Install the package before running the tests
     if install:
         ctx.run("python -m pip install .[test]")
@@ -63,6 +63,8 @@ def test(ctx, filter=None, junit=False, install=False):
         args += "--junit-xml test-results.xml"
     if filter is not None:
         args += " -k '{}'".format(filter)
+    if html:
+        args += "--html results.html"
     ctx.run("python -m pytest {} {}".format(os.path.join(ROOT_DIR, "tests"), args))
 
 test_tasks.add_task(test, default=True)

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -64,37 +64,37 @@ def test_import():
 
 # -----------------------------------------------------------------------------
 def test_app_imports():
-    from bumble.apps.console import main
+    from apps.console import main
     assert main
 
-    from bumble.apps.controller_info import main
+    from apps.controller_info import main
     assert main
 
-    from bumble.apps.controllers import main
+    from apps.controllers import main
     assert main
 
-    from bumble.apps.gatt_dump import main
+    from apps.gatt_dump import main
     assert main
 
-    from bumble.apps.gg_bridge import main
+    from apps.gg_bridge import main
     assert main
 
-    from bumble.apps.hci_bridge import main
+    from apps.hci_bridge import main
     assert main
 
-    from bumble.apps.pair import main
+    from apps.pair import main
     assert main
 
-    from bumble.apps.scan import main
+    from apps.scan import main
     assert main
 
-    from bumble.apps.show import main
+    from apps.show import main
     assert main
 
-    from bumble.apps.unbond import main
+    from apps.unbond import main
     assert main
 
-    from bumble.apps.usb_probe import main
+    from apps.usb_probe import main
     assert main
 
 


### PR DESCRIPTION
a. `DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead` Updated call in `bumble/smp.py`

b. `ModuleNotFoundError: No module named 'bumble.apps'` Updated imports in `tests/import_test.py`

c. Added `pytest-html` for easier viewing of test results Added package in `setup.cfg`, and hook in `tasks.py`

d. Updated workflows to use `invoke test`

This is a partial fix of #81