### PR TITLE
use libusb auto-detach feature

### DIFF
--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -414,14 +414,13 @@ async def open_usb_transport(spec):
 
         device = found.open()
 
-        # Detach the kernel driver if supported and needed
+        # Auto-detach the kernel driver if supported
         if usb1.hasCapability(usb1.CAP_SUPPORTS_DETACH_KERNEL_DRIVER):
             try:
-                if device.kernelDriverActive(interface):
-                    logger.debug("detaching kernel driver")
-                    device.detachKernelDriver(interface)
-            except usb1.USBError:
-                pass
+                logger.debug('auto-detaching kernel driver')
+                device.setAutoDetachKernelDriver(True)
+            except usb1.USBError as error:
+                logger.warning(f'unable to auto-detach kernel driver: {error}')
 
         # Set the configuration if needed
         try:


### PR DESCRIPTION
The `usb` transport was unconditionally detaching the kernel driver for an interface when claiming it (when supported), but wasn't re-attaching it when releasing the interface. As a result, a USB controller would stop being visible to the kernel after using this transport on Linux.
This PR uses `libusb`'s auto-detach feature, which will automatically detach, the re-attach, the kernel driver when the interface is claimed then released.