### PR TITLE
Add `bumble-console --device-config` support for gatt services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@ build/
 dist/
 *.egg-info/
 *~
-bumble/__pycache__
 docs/mkdocs/site
-tests/__pycache__
 test-results.xml
-bumble/transport/__pycache__
-bumble/profiles/__pycache__
+__pycache__

--- a/bumble/core.py
+++ b/bumble/core.py
@@ -58,6 +58,12 @@ def padded_bytes(buffer, size):
     return buffer + bytes(padding_size)
 
 
+def get_dict_key_by_value(dictionary, value):
+    for key, val in dictionary.items():
+        if val == value:
+            return key
+    return None
+
 # -----------------------------------------------------------------------------
 # Exceptions
 # -----------------------------------------------------------------------------
@@ -135,7 +141,7 @@ class UUID:
             else:
                 uuid_str = uuid_str_or_int
             if len(uuid_str) != 32 and len(uuid_str) != 8 and len(uuid_str) != 4:
-                raise ValueError('invalid UUID format')
+                raise ValueError(f"invalid UUID format: {uuid_str}")
             self.uuid_bytes = bytes(reversed(bytes.fromhex(uuid_str)))
         self.name = name
 

--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -22,6 +22,7 @@
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
+from __future__ import annotations
 import asyncio
 import enum
 import types
@@ -187,7 +188,7 @@ class Service(Attribute):
     See Vol 3, Part G - 3.1 SERVICE DEFINITION
     '''
 
-    def __init__(self, uuid, characteristics, primary=True):
+    def __init__(self, uuid, characteristics: list[Characteristic], primary=True):
         # Convert the uuid to a UUID object if it isn't already
         if type(uuid) is str:
             uuid = UUID(uuid)
@@ -256,10 +257,21 @@ class Characteristic(Attribute):
             if properties & p
         ])
 
-    def __init__(self, uuid, properties, permissions, value = b'', descriptors = []):
+    @staticmethod
+    def string_to_properties(properties_str: str):
+        return functools.reduce(
+            lambda x, y: x | get_dict_key_by_value(Characteristic.PROPERTY_NAMES, y),
+            properties_str.split(","),
+            0,
+        )
+
+    def __init__(self, uuid, properties, permissions, value = b'', descriptors: list[Descriptor] = []):
         super().__init__(uuid, permissions, value)
         self.uuid        = self.type
-        self.properties  = properties
+        if type(properties) is str:
+            self.properties = Characteristic.string_to_properties(properties)
+        else:
+            self.properties = properties
         self.descriptors = descriptors
 
     def get_descriptor(self, descriptor_type):

--- a/bumble/gatt_server.py
+++ b/bumble/gatt_server.py
@@ -60,6 +60,9 @@ class Server(EventEmitter):
         self.indication_semaphores = defaultdict(lambda: asyncio.Semaphore(1))
         self.pending_confirmations = defaultdict(lambda: None)
 
+    def __str__(self):
+        return "\n".join(map(str, self.attributes))
+
     def send_gatt_pdu(self, connection_handle, pdu):
         self.device.send_l2cap_pdu(connection_handle, ATT_CID, pdu)
 
@@ -87,7 +90,7 @@ class Server(EventEmitter):
         # Add this attribute to the list
         self.attributes.append(attribute)
 
-    def add_service(self, service):
+    def add_service(self, service: Service):
         # Add the service attribute to the DB
         self.add_attribute(service)
 

--- a/tasks.py
+++ b/tasks.py
@@ -52,8 +52,9 @@ build_tasks.add_task(mkdocs, name="mkdocs")
 test_tasks = Collection()
 ns.add_collection(test_tasks, name="test")
 
-@task
-def test(ctx, filter=None, junit=False, install=False, html=False):
+
+@task(incrementable=["verbose"])
+def test(ctx, filter=None, junit=False, install=False, html=False, verbose=0):
     # Install the package before running the tests
     if install:
         ctx.run("python -m pip install .[test]")
@@ -62,10 +63,12 @@ def test(ctx, filter=None, junit=False, install=False, html=False):
     if junit:
         args += "--junit-xml test-results.xml"
     if filter is not None:
-        args += " -k '{}'".format(filter)
+        args += f" -k '{filter}'"
     if html:
-        args += "--html results.html"
-    ctx.run("python -m pytest {} {}".format(os.path.join(ROOT_DIR, "tests"), args))
+        args += " --html results.html"
+    if verbose > 0:
+        args += f" -{'v' * verbose}"
+    ctx.run(f"python -m pytest {os.path.join(ROOT_DIR, 'tests')} {args}")
 
 test_tasks.add_task(test, default=True)
 

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -15,8 +15,7 @@
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
-from bumble.core import AdvertisingData
-
+from bumble.core import AdvertisingData, get_dict_key_by_value
 
 # -----------------------------------------------------------------------------
 def test_ad_data():
@@ -38,6 +37,16 @@ def test_ad_data():
     assert(ad.get(AdvertisingData.COMPLETE_LOCAL_NAME, return_all=True, raw=True) == [])
     assert(ad.get(AdvertisingData.TX_POWER_LEVEL, return_all=True, raw=True) == [bytes([123]), bytes([234])])
 
+
+# -----------------------------------------------------------------------------
+def test_get_dict_key_by_value():
+    dictionary = {
+        "A": 1,
+        "B": 2
+    }
+    assert get_dict_key_by_value(dictionary, 1) == "A"
+    assert get_dict_key_by_value(dictionary, 2) == "B"
+    assert get_dict_key_by_value(dictionary, 3) is None
 
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds support for bumble-console to be preloaded with gatt services via `--device-config`.

This PR also adds some type annotations.

Formally #66 