### PR TITLE
fix libusb loading on Windows

### DIFF
--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -46,8 +46,9 @@ def load_libusb():
     when usb1.USBContext is created.
     '''
     if libusb_path := libusb_package.get_library_path():
+        logger.debug(f'loading libusb library at {libusb_path}')
         dll_loader = ctypes.WinDLL if platform.system() == 'Windows' else ctypes.CDLL
-        libusb_dll = dll_loader(libusb_path, use_errno=True, use_last_error=True)
+        libusb_dll = dll_loader(str(libusb_path), use_errno=True, use_last_error=True)
         usb1.loadLibrary(libusb_dll)
 
 


### PR DESCRIPTION
A recent change to use `libusb_package` for loading `libusb` broke support for Windows, because `get_library_path` returns a `WindowsPath`, not an `str`, which isn't iterable.
This PR converts the path to an `str` before invoking `ctypes.CDLL` or `ctypes.WinDLL`.