### PR TITLE
Fix bug when use hci-socket transport

### DIFF
--- a/bumble/transport/hci_socket.py
+++ b/bumble/transport/hci_socket.py
@@ -97,7 +97,7 @@ async def open_hci_socket_transport(spec):
             super().__init__()
             self.socket = hci_socket
             asyncio.get_running_loop().add_reader(
-                socket.fileno(), self.recv_until_would_block
+                self.socket.fileno(), self.recv_until_would_block
             )
 
         def recv_until_would_block(self):
@@ -140,7 +140,7 @@ async def open_hci_socket_transport(spec):
                 if not self.writer_added:
                     asyncio.get_running_loop().add_writer(
                         # pylint: disable=no-member
-                        socket.fileno(),
+                        self.socket.fileno(),
                         self.send_until_would_block,
                     )
                     self.writer_added = True


### PR DESCRIPTION
Calling 
`python3 examples/device_information_server.py examples/device1.json hci-socket`
produces error:
`  File "/home/server/bumble/venv/lib/python3.10/site-packages/bumble/transport/hci_socket.py", line 100, in __init__
    socket.fileno(), self.recv_until_would_block
AttributeError: module 'socket' has no attribute 'fileno'`
File `transport/hci_socket.py` was changed to fix this bug.