### PR TITLE
don't set a random address when it is 00:00:00:00:00:00

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1113,10 +1113,13 @@ class Device(CompositeEventEmitter):
 
         if self.le_enabled:
             # Set the controller address
-            await self.send_command(
-                HCI_LE_Set_Random_Address_Command(random_address=self.random_address),
-                check_result=True,
-            )
+            if self.random_address != Address.ANY_RANDOM:
+                await self.send_command(
+                    HCI_LE_Set_Random_Address_Command(
+                        random_address=self.random_address
+                    ),
+                    check_result=True,
+                )
 
             # Load the address resolving list
             if self.keystore and self.host.supports_command(

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -1638,8 +1638,8 @@ class HCI_Object:
             # Map the value if needed
             if value_mappers:
                 value_mapper = value_mappers.get(key, value_mapper)
-                if value_mapper is not None:
-                    value = value_mapper(value)
+            if value_mapper is not None:
+                value = value_mapper(value)
 
             # Get the string representation of the value
             value_str = HCI_Object.format_field_value(
@@ -1807,6 +1807,7 @@ class Address:
 # Predefined address values
 Address.NIL = Address(b"\xff\xff\xff\xff\xff\xff", Address.PUBLIC_DEVICE_ADDRESS)
 Address.ANY = Address(b"\x00\x00\x00\x00\x00\x00", Address.PUBLIC_DEVICE_ADDRESS)
+Address.ANY_RANDOM = Address(b"\x00\x00\x00\x00\x00\x00", Address.RANDOM_DEVICE_ADDRESS)
 
 # -----------------------------------------------------------------------------
 class OwnAddressType:

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -3107,6 +3107,16 @@ class HCI_LE_Read_Remote_Features_Command(HCI_Command):
 
 # -----------------------------------------------------------------------------
 @HCI_Command.command(
+    return_parameters_fields=[("status", STATUS_SPEC), ("random_number", 8)]
+)
+class HCI_LE_Rand_Command(HCI_Command):
+    """
+    See Bluetooth spec @ 7.8.23 LE Rand Command
+    """
+
+
+# -----------------------------------------------------------------------------
+@HCI_Command.command(
     [
         ('connection_handle', 2),
         ('random_number', 8),


### PR DESCRIPTION
Some controllers don't like it when invoking HCI_LE_Set_Random_Address_Command with an all-0s address.
So, when using a device with a config where no random address is set, don't send such an address.
 