### PR TITLE
fix libusb-package dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     cryptography == 35; platform_system!='Emscripten'
     grpcio >= 1.46; platform_system!='Emscripten'
     libusb1 >= 2.0.1; platform_system!='Emscripten'
-    libusb-package == 1.0.26.0; platform_system!='Emscripten'
+    libusb-package == 1.0.26.1; platform_system!='Emscripten'
     prompt_toolkit >= 3.0.16; platform_system!='Emscripten'
     protobuf >= 3.12.4
     pyee >= 8.2.2


### PR DESCRIPTION
The previous version was missing `tomli` as a dependency, thus breaking on some platforms.
