### PR TITLE
build: fix version of packages running checks in CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,11 +73,11 @@ test =
     pytest-html >= 3.2.0
     coverage >= 6.4
 development =
-    black >= 22.10
+    black == 22.10
     invoke >= 1.7.3
-    mypy >= 0.991
+    mypy == 0.991
     nox >= 2022
-    pylint >= 2.15.8
+    pylint == 2.15.8
     types-appdirs >= 1.4.3
     types-invoke >= 1.7.3
     types-protobuf >= 4.21.0


### PR DESCRIPTION
I was wondering why black was re-formatting files differently form `main`.
I suggest this change to make sure it does not happen