### PR TITLE
utils: fix possible invalide state error while canceling future for `abort_on`

### DIFF
--- a/bumble/utils.py
+++ b/bumble/utils.py
@@ -78,6 +78,8 @@ class AbortableEventEmitter(EventEmitter):
             return future
 
         def on_event(*_):
+            if future.done():
+                return
             msg = f'abort: {event} event occurred.'
             if isinstance(future, asyncio.Task):
                 # python < 3.9 does not support passing a message on `Task.cancel`


### PR DESCRIPTION
Nothing prevent the future to be completed before `on_event` call, this change fix that