### PR TITLE
fix getting the filename from the keystore option.

### DIFF
--- a/apps/pair.py
+++ b/apps/pair.py
@@ -366,7 +366,7 @@ async def pair(
     '--request', is_flag=True, help='Request that the connecting peer initiate pairing'
 )
 @click.option('--print-keys', is_flag=True, help='Print the bond keys before pairing')
-@click.option('--keystore-file', help='File in which to store the pairing keys')
+@click.option('--keystore-file', metavar='<filename>', help='File in which to store the pairing keys')
 @click.argument('device-config')
 @click.argument('hci_transport')
 @click.argument('address-or-name', required=False)

--- a/apps/pair.py
+++ b/apps/pair.py
@@ -366,7 +366,11 @@ async def pair(
     '--request', is_flag=True, help='Request that the connecting peer initiate pairing'
 )
 @click.option('--print-keys', is_flag=True, help='Print the bond keys before pairing')
-@click.option('--keystore-file', metavar='<filename>', help='File in which to store the pairing keys')
+@click.option(
+    '--keystore-file',
+    metavar='<filename>',
+    help='File in which to store the pairing keys',
+)
 @click.argument('device-config')
 @click.argument('hci_transport')
 @click.argument('address-or-name', required=False)

--- a/bumble/keys.py
+++ b/bumble/keys.py
@@ -217,7 +217,7 @@ class JsonKeyStore(KeyStore):
         params = device_config.keystore.split(':', 1)[1:]
         namespace = str(device_config.address)
         if params:
-            filename = params[1]
+            filename = params[0]
         else:
             filename = None
 

--- a/bumble/keys.py
+++ b/bumble/keys.py
@@ -130,7 +130,7 @@ class PairingKeys:
                 for (key_property, key_value) in value.items():
                     print(f'{prefix}  {color(key_property, "green")}: {key_value}')
             else:
-                print(f'{prefix}{color(property, "cyan")}: {value}')
+                print(f'{prefix}{color(container_property, "cyan")}: {value}')
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
As reported in #124 specifying a filename in a device config when using the `JsonKeyStore` keystore would fail.
Ex: `"keystore": "JsonKeyStore:mykeys.json"`
