### PR TITLE
Fix small bug with services set via --device-config

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -999,7 +999,7 @@ class Device(CompositeEventEmitter):
                 new_characteristic = Characteristic(
                     uuid=characteristic["uuid"],
                     properties=characteristic["properties"],
-                    permissions=int(characteristic["permissions"], 0),
+                    permissions=characteristic["permissions"],
                     descriptors=descriptors,
                 )
                 characteristics.append(new_characteristic)

--- a/tests/gatt_test.py
+++ b/tests/gatt_test.py
@@ -37,10 +37,12 @@ from bumble.gatt import (
     Service,
     Characteristic,
     CharacteristicValue,
+    Descriptor,
 )
 from bumble.transport import AsyncPipeSink
 from bumble.core import UUID
 from bumble.att import (
+    Attribute,
     ATT_EXCHANGE_MTU_REQUEST,
     ATT_ATTRIBUTE_NOT_FOUND_ERROR,
     ATT_PDU,
@@ -859,6 +861,29 @@ async def async_main():
     await test_subscribe_notify()
     await test_characteristic_encoding()
     await test_mtu_exchange()
+
+
+# -----------------------------------------------------------------------------
+def test_attribute_string_to_permissions():
+    assert Attribute.string_to_permissions('READABLE') == 1
+    assert Attribute.string_to_permissions('WRITEABLE') == 2
+    assert Attribute.string_to_permissions('READABLE,WRITEABLE') == 3
+
+
+# -----------------------------------------------------------------------------
+def test_charracteristic_permissions():
+    characteristic = Characteristic(
+        'FDB159DB-036C-49E3-B3DB-6325AC750806',
+        Characteristic.READ | Characteristic.WRITE | Characteristic.NOTIFY,
+        'READABLE,WRITEABLE',
+    )
+    assert characteristic.permissions == 3
+
+
+# -----------------------------------------------------------------------------
+def test_descriptor_permissions():
+    descriptor = Descriptor('2902', 'READABLE,WRITEABLE')
+    assert descriptor.permissions == 3
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
before:
```
  File "/home/alanrosenthal/code/fitbit/bumble/bumble/gatt.py", line 572, in __str__
    f'Descriptor(handle=0x{self.handle:04X}, '
  File "/home/alanrosenthal/code/fitbit/bumble/bumble/att.py", line 756, in read_value
    self.permissions & self.READ_REQUIRES_ENCRYPTION
TypeError: unsupported operand type(s) for &: 'str' and 'int'
```