### PR TITLE
Fix typo when parsing device-config's gatt server

### DIFF
--- a/bumble/att.py
+++ b/bumble/att.py
@@ -739,11 +739,16 @@ class Attribute(EventEmitter):
 
     @staticmethod
     def string_to_permissions(permissions_str: str):
-        return functools.reduce(
-            lambda x, y: x | get_dict_key_by_value(Attribute.PERMISSION_NAMES, y),
-            permissions_str.split(","),
-            0,
-        )
+        try:
+            return functools.reduce(
+                lambda x, y: x | get_dict_key_by_value(Attribute.PERMISSION_NAMES, y),
+                permissions_str.split(","),
+                0,
+            )
+        except TypeError:
+            raise TypeError(
+                f"Attribute::permissions error:\nExpected a string containing any of the keys, seperated by commas: {','.join(Attribute.PERMISSION_NAMES.values())}\nGot: {permissions_str}"
+            )
 
     def __init__(self, attribute_type, permissions, value=b''):
         EventEmitter.__init__(self)

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1000,9 +1000,14 @@ class Device(CompositeEventEmitter):
             for characteristic in service.get("characteristics", []):
                 descriptors = []
                 for descriptor in characteristic.get("descriptors", []):
+                    # Leave this check until 5/25/2023
+                    if descriptor.get("permission", False):
+                        raise Exception(
+                            "Error parsing Device Config's GATT Services. The key 'permission' must be renamed to 'permissions'"
+                        )
                     new_descriptor = Descriptor(
                         attribute_type=descriptor["descriptor_type"],
-                        permissions=descriptor["permission"],
+                        permissions=descriptor["permissions"],
                     )
                     descriptors.append(new_descriptor)
                 new_characteristic = Characteristic(


### PR DESCRIPTION
* 'permission' instead of 'permissions'
* Also added a more user friendly error message when Attribute.string_to_permissions fails
```
TypeError: Attribute::permissions error:
Expected a string containing any of the keys, seperated by commas: READABLE,WRITEABLE,READ_REQUIRES_ENCRYPTION,WRITE_REQUIRES_ENCRYPTION,READ_REQUIRES_AUTHENTICATION,WRITE_REQUIRES_AUTHENTICATION,READ_REQUIRES_AUTHORIZATION,WRITE_REQUIRES_AUTHORIZATION
Got: 1
```
```
Exception: Error parsing Device Config's GATT Services. The key 'permission' must be renamed to 'permissions'
```