### PR TITLE
smp: fix `PairingDelegate.get_number` return type

### DIFF
--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -522,7 +522,11 @@ class PairingDelegate:
     async def compare_numbers(self, number: int, digits: int) -> bool:
         return True
 
-    async def get_number(self) -> int:
+    async def get_number(self) -> Optional[int]:
+        '''
+        Returns an optional number as an answer to a passkey request.
+        Returning `None` will result in a negative reply.
+        '''
         return 0
 
     # pylint: disable-next=unused-argument


### PR DESCRIPTION
This function can return `None` to indicate a negative reply, update the type hint accordingly.