### PR TITLE
use device public or static address for keystore namespace

### DIFF
--- a/apps/gg_bridge.py
+++ b/apps/gg_bridge.py
@@ -339,8 +339,7 @@ async def run(
 
         # Create a UDP to TX bridge (receive from TX, send to UDP)
         bridge.tx_socket, _ = await loop.create_datagram_endpoint(
-            # pylint: disable-next=unnecessary-lambda
-            lambda: asyncio.DatagramProtocol(),
+            asyncio.DatagramProtocol,
             remote_addr=(send_host, send_port),
         )
 

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1179,7 +1179,8 @@ class Device(CompositeEventEmitter):
 
         # Instantiate the Key Store (we do this here rather than at __init__ time
         # because some Key Store implementations use the public address as a namespace)
-        self.keystore = KeyStore.create_for_device(self)
+        if self.keystore is None:
+            self.keystore = KeyStore.create_for_device(self)
 
         if self.host.supports_command(HCI_WRITE_LE_HOST_SUPPORT_COMMAND):
             await self.send_command(


### PR DESCRIPTION
Instead of just using the device static random address, use the most likely identifier for the controller as the namespace for keystores:
  * Try the public address first if the controller has one
  * Second choice is the static random address assigned to the controller
  * Otherwise: default namespace.