### PR TITLE
fix role state for classic connections

### DIFF
--- a/apps/pair.py
+++ b/apps/pair.py
@@ -264,6 +264,7 @@ async def pair(
     sc,
     mitm,
     bond,
+    ctkd,
     io,
     prompt,
     request,
@@ -317,6 +318,7 @@ async def pair(
         if mode == 'classic':
             device.classic_enabled = True
             device.le_enabled = False
+            device.classic_smp_enabled = ctkd
 
         # Get things going
         await device.power_on()
@@ -380,6 +382,13 @@ class LogHandler(logging.Handler):
     '--bond', type=bool, default=True, help='Enable bonding', show_default=True
 )
 @click.option(
+    '--ctkd',
+    type=bool,
+    default=True,
+    help='Enable CTKD',
+    show_default=True,
+)
+@click.option(
     '--io',
     type=click.Choice(
         ['keyboard', 'display', 'display+keyboard', 'display+yes/no', 'none']
@@ -405,6 +414,7 @@ def main(
     sc,
     mitm,
     bond,
+    ctkd,
     io,
     prompt,
     request,
@@ -427,6 +437,7 @@ def main(
             sc,
             mitm,
             bond,
+            ctkd,
             io,
             prompt,
             request,

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1950,7 +1950,10 @@ class Device(CompositeEventEmitter):
         self.on('connection', on_connection)
         self.on('connection_failure', on_connection_failure)
 
-        # Save pending connection
+        # Save pending connection, with the Peripheral role.
+        # Even if we requested a role switch in the HCI_Accept_Connection_Request
+        # command, this connection is still considered Peripheral until an eventual
+        # role change event.
         self.pending_connections[peer_address] = Connection.incomplete(
             self, peer_address, BT_PERIPHERAL_ROLE
         )

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -94,10 +94,9 @@ HOST_HC_TOTAL_NUM_ACL_DATA_PACKETS        = 1
 
 # -----------------------------------------------------------------------------
 class Connection:
-    def __init__(self, host, handle, role, peer_address, transport):
+    def __init__(self, host, handle, peer_address, transport):
         self.host = host
         self.handle = handle
-        self.role = role
         self.peer_address = peer_address
         self.assembler = HCI_AclDataPacketAssembler(self.on_acl_pdu)
         self.transport = transport
@@ -534,7 +533,7 @@ class Host(AbortableEventEmitter):
         if event.status == HCI_SUCCESS:
             # Create/update the connection
             logger.debug(
-                f'### CONNECTION: [0x{event.connection_handle:04X}] '
+                f'### LE CONNECTION: [0x{event.connection_handle:04X}] '
                 f'{event.peer_address} as {HCI_Constant.role_name(event.role)}'
             )
 
@@ -543,7 +542,6 @@ class Host(AbortableEventEmitter):
                 connection = Connection(
                     self,
                     event.connection_handle,
-                    event.role,
                     event.peer_address,
                     BT_LE_TRANSPORT,
                 )
@@ -560,7 +558,6 @@ class Host(AbortableEventEmitter):
                 event.connection_handle,
                 BT_LE_TRANSPORT,
                 event.peer_address,
-                None,
                 event.role,
                 connection_parameters,
             )
@@ -589,7 +586,6 @@ class Host(AbortableEventEmitter):
                 connection = Connection(
                     self,
                     event.connection_handle,
-                    BT_CENTRAL_ROLE,
                     event.bd_addr,
                     BT_BR_EDR_TRANSPORT,
                 )
@@ -602,7 +598,6 @@ class Host(AbortableEventEmitter):
                 BT_BR_EDR_TRANSPORT,
                 event.bd_addr,
                 None,
-                BT_CENTRAL_ROLE,
                 None,
             )
         else:
@@ -622,8 +617,7 @@ class Host(AbortableEventEmitter):
         if event.status == HCI_SUCCESS:
             logger.debug(
                 f'### DISCONNECTION: [0x{event.connection_handle:04X}] '
-                f'{connection.peer_address} as '
-                f'{HCI_Constant.role_name(connection.role)}, '
+                f'{connection.peer_address} '
                 f'reason={event.reason}'
             )
             del self.connections[event.connection_handle]
@@ -739,10 +733,6 @@ class Host(AbortableEventEmitter):
                 f'role change for {event.bd_addr}: '
                 f'{HCI_Constant.role_name(event.new_role)}'
             )
-            if connection := self.find_connection_by_bd_addr(
-                event.bd_addr, BT_BR_EDR_TRANSPORT
-            ):
-                connection.role = event.new_role
             self.emit('role_change', event.bd_addr, event.new_role)
         else:
             logger.debug(

--- a/bumble/keys.py
+++ b/bumble/keys.py
@@ -273,7 +273,7 @@ class JsonKeyStore(KeyStore):
         db = await self.load()
 
         namespace = db.setdefault(self.namespace, {})
-        namespace[name] = keys.to_dict()
+        namespace.setdefault(name, {}).update(keys.to_dict())
 
         await self.save(db)
 

--- a/bumble/rfcomm.py
+++ b/bumble/rfcomm.py
@@ -439,7 +439,7 @@ class DLC(EventEmitter):
 
             logger.debug(
                 f'<<< Credits [{self.dlci}]: '
-                f'received {credits}, total={self.tx_credits}'
+                f'received {received_credits}, total={self.tx_credits}'
             )
             data = data[1:]
 

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -553,7 +553,7 @@ class PairingConfig:
     def __init__(
         self,
         sc: bool = True,
-        mitm: bool = True,
+        mitm: bool = False,
         bonding: bool = True,
         delegate: Optional[PairingDelegate] = None,
     ) -> None:

--- a/examples/hfp_handsfree.json
+++ b/examples/hfp_handsfree.json
@@ -1,4 +1,6 @@
 {
     "name": "Bumble Hands-Free",
-    "class_of_device": 2360324
+    "class_of_device": 2360324,
+    "keystore": "JsonKeyStore",
+    "le_enabled": false
 }

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -447,7 +447,7 @@ async def test_self_smp_wrong_pin():
         async def compare_numbers(self, number, digits):
             return False
 
-    wrong_pin_pairing_config = PairingConfig(delegate=WrongPinDelegate())
+    wrong_pin_pairing_config = PairingConfig(mitm=True, delegate=WrongPinDelegate())
     paired = False
     try:
         await _test_self_smp_with_configs(


### PR DESCRIPTION
Somehow the connection role wasn't handled quite right for Classic connections (because we don't know the role at the time of connection, the role is temporarily unknown). This caused CTKD to fail, because over a Classic connection, as a peripheral, the SMP would not distribute keys in response to an SMP pairing request since it incorrectly thought it was the central.
This PR removes the `role` attribute in the host-level connection object (it's actually not needed there).
Also, this removes the `resolved_peer_address` property for Classic connections, since there's no concept of resolvable keys there, that property isn't relevant.
Finally, there's limited support for disabling SMP over Classic connection, for when a device doesn't want to participate in Classic CTKD.