### PR TITLE
only use 1M parameters by default

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1611,7 +1611,7 @@ class Device(CompositeEventEmitter):
         pending connection.
 
         connection_parameters_preferences: (BLE only, ignored for BR/EDR)
-          * None: use all PHYs with default parameters
+          * None: use the 1M PHY with default parameters
           * map: each entry has a PHY as key and a ConnectionParametersPreferences
             object as value
 
@@ -1680,9 +1680,7 @@ class Device(CompositeEventEmitter):
                 if connection_parameters_preferences is None:
                     if connection_parameters_preferences is None:
                         connection_parameters_preferences = {
-                            HCI_LE_1M_PHY: ConnectionParametersPreferences.default,
-                            HCI_LE_2M_PHY: ConnectionParametersPreferences.default,
-                            HCI_LE_CODED_PHY: ConnectionParametersPreferences.default,
+                            HCI_LE_1M_PHY: ConnectionParametersPreferences.default
                         }
 
                 self.connect_own_address_type = own_address_type


### PR DESCRIPTION
Some controllers, like Zephyr-based controllers, don't like it when passing multiple connection parameters in the connection request (even if the PHY is supported). For example, with a Zephyr controller (from the Zephyr HCI USB example), when not specifying explicit parameters in the connection request (which is what most of the tools and examples do), this would lead
to the controller returning `HCI_UNSUPPORTED_FEATURE_OR_PARAMETER_VALUE_ERROR`.
This change is for only specifying default values for 1M if no explicit preferences are passed (you can still pass arbitrary sets if you want, this only changes the default). It also seems reasonable to pick only 1M by default, since that's the expected baseline for all controllers.
