### PR TITLE
temporarily pin click to 8.1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     aiohttp ~= 3.8; platform_system!='Emscripten'
     appdirs >= 1.4
     bt-test-interfaces >= 0.0.2
-    click >= 7.1.2; platform_system!='Emscripten'
+    click == 8.1.3; platform_system!='Emscripten'
     cryptography == 35; platform_system!='Emscripten'
     grpcio == 1.51.1; platform_system!='Emscripten'
     humanize >= 4.6.0


### PR DESCRIPTION
Click 8.1.4 introduced a typing change that breaks type checking in several places.
This temporarily pins `click` at 8.1.3 until https://github.com/pallets/click/issues/2558 is fixed.