### PR TITLE
use r0 by default for classic connection requests

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -58,7 +58,7 @@ from .hci import (
     HCI_MITM_REQUIRED_GENERAL_BONDING_AUTHENTICATION_REQUIREMENTS,
     HCI_MITM_REQUIRED_NO_BONDING_AUTHENTICATION_REQUIREMENTS,
     HCI_NO_INPUT_NO_OUTPUT_IO_CAPABILITY,
-    HCI_R2_PAGE_SCAN_REPETITION_MODE,
+    HCI_R0_PAGE_SCAN_REPETITION_MODE,
     HCI_REMOTE_USER_TERMINATED_CONNECTION_ERROR,
     HCI_SUCCESS,
     HCI_WRITE_LE_HOST_SUPPORT_COMMAND,
@@ -1842,7 +1842,7 @@ class Device(CompositeEventEmitter):
                     HCI_Create_Connection_Command(
                         bd_addr=peer_address,
                         packet_type=0xCC18,  # FIXME: change
-                        page_scan_repetition_mode=HCI_R2_PAGE_SCAN_REPETITION_MODE,
+                        page_scan_repetition_mode=HCI_R0_PAGE_SCAN_REPETITION_MODE,
                         clock_offset=0x0000,
                         allow_role_switch=0x01,
                         reserved=0,


### PR DESCRIPTION
I don't remember why this was set as r2 by default, but r0 is a better default, as it will connect better/faster.
(a future PR should allow this to be customized of course)