### PR TITLE
Add a space after RSSI

### DIFF
--- a/examples/run_scanner.py
+++ b/examples/run_scanner.py
@@ -62,7 +62,7 @@ async def main():
             print(
                 f'>>> {color(advertisement.address, address_color)} '
                 f'[{color(address_type_string, type_color)}]'
-                f'{address_qualifier}:{separator}RSSI:{advertisement.rssi}'
+                f'{address_qualifier}:{separator}RSSI: {advertisement.rssi}'
                 f'{separator}'
                 f'{advertisement.data.to_string(separator)}'
             )


### PR DESCRIPTION
The other data elements have a space, so I'm guessing that RSSI is intended to as well. Perhaps there's some subtle reason why it should have a space, though, in which case feel free to close this.

Output now looks like this:

```
>>> 58:D3:49:E7:40:DA/P [PUBLIC]:
  RSSI: -67
  [Flags]: LE General,BR/EDR C,BR/EDR H
  [TX Power Level]: 4
  [Manufacturer Specific Data]: company=Apple, Inc., data=0f08c00af4392b00040c10020f04
```