### PR TITLE
Pandora: Allow auto numeric comparison

### DIFF
--- a/bumble/pandora/security.py
+++ b/bumble/pandora/security.py
@@ -119,7 +119,7 @@ class PairingDelegate(BasePairingDelegate):
         )
 
         if self.service.event_queue is None or self.service.event_answer is None:
-            raise RuntimeError('security: unhandled number comparison request')
+            return True
 
         event = self.add_origin(PairingEvent(numeric_comparison=number))
         self.service.event_queue.put_nowait(event)


### PR DESCRIPTION
Allow auto numeric comparison can help users build apps requiring high-security level easily. We also have the same design on Android.