### PR TITLE
Handle SSP Complete events

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -2743,20 +2743,6 @@ class Device(CompositeEventEmitter):
         )
         connection.emit('connection_authentication_failure', error)
 
-    @host_event_handler
-    @with_connection_from_address
-    def on_ssp_complete(self, connection):
-        # On Secure Simple Pairing complete, in case:
-        # - Connection isn't already authenticated
-        # - AND we are not the initiator of the authentication
-        # We must trigger authentication to know if we are truly authenticated
-        if not connection.authenticating and not connection.authenticated:
-            logger.debug(
-                f'*** Trigger Connection Authentication: [0x{connection.handle:04X}] '
-                f'{connection.peer_address}'
-            )
-            asyncio.create_task(connection.authenticate())
-
     # [Classic only]
     @host_event_handler
     @with_connection_from_address
@@ -3110,6 +3096,18 @@ class Device(CompositeEventEmitter):
         if connection:
             connection.emit('role_change_failure', error)
         self.emit('role_change_failure', address, error)
+
+    # [Classic only]
+    @host_event_handler
+    @with_connection_from_address
+    def on_classic_pairing(self, connection: Connection) -> None:
+        connection.emit('classic_pairing')
+
+    # [Classic only]
+    @host_event_handler
+    @with_connection_from_address
+    def on_classic_pairing_failure(self, connection: Connection, status) -> None:
+        connection.emit('classic_pairing_failure', status)
 
     def on_pairing_start(self, connection: Connection) -> None:
         connection.emit('pairing_start')

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -822,6 +822,10 @@ class Host(AbortableEventEmitter):
             f'simple pairing complete for {event.bd_addr}: '
             f'status={HCI_Constant.status_name(event.status)}'
         )
+        if event.status == HCI_SUCCESS:
+            self.emit('classic_pairing', event.bd_addr)
+        else:
+            self.emit('classic_pairing_failure', event.bd_addr, event.status)
 
     def on_hci_pin_code_request_event(self, event):
         self.emit('pin_code_request', event.bd_addr)

--- a/bumble/pandora/security.py
+++ b/bumble/pandora/security.py
@@ -423,6 +423,8 @@ class SecurityService(SecurityServicer):
             'pairing': try_set_success,
             'connection_authentication': try_set_success,
             'connection_encryption_change': on_encryption_change,
+            'classic_pairing': try_set_success,
+            'classic_pairing_failure': set_failure('pairing_failure'),
         }
 
         # register event handlers


### PR DESCRIPTION
A refined version of https://github.com/google/bumble/pull/187

`on_ssp_complete()` is removed due to no usage, and this logic should be handled by applications.