### PR TITLE
add sink method for lost transports

### DIFF
--- a/bumble/controller.py
+++ b/bumble/controller.py
@@ -188,6 +188,8 @@ class Controller:
         if link:
             link.add_controller(self)
 
+        self.terminated = asyncio.get_running_loop().create_future()
+
     @property
     def host(self):
         return self.hci_sink
@@ -288,10 +290,9 @@ class Controller:
         if self.host:
             self.host.on_packet(packet.to_bytes())
 
-    # This method allow the controller to emulate the same API as a transport source
+    # This method allows the controller to emulate the same API as a transport source
     async def wait_for_termination(self):
-        # For now, just wait forever
-        await asyncio.get_running_loop().create_future()
+        await self.terminated
 
     ############################################################
     # Link connections

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -459,6 +459,8 @@ class Host(AbortableEventEmitter):
         if self.pending_response:
             self.pending_response.set_exception(TransportLostError('transport lost'))
 
+        self.emit('flush')
+
     def on_hci_packet(self, packet):
         logger.debug(f'{color("### CONTROLLER -> HOST", "green")}: {packet}')
 

--- a/bumble/transport/tcp_client.py
+++ b/bumble/transport/tcp_client.py
@@ -39,7 +39,7 @@ async def open_tcp_client_transport(spec):
     class TcpPacketSource(StreamPacketSource):
         def connection_lost(self, exc):
             logger.debug(f'connection lost: {exc}')
-            self.terminated.set_result(exc)
+            self.on_transport_lost()
 
     remote_host, remote_port = spec.split(':')
     tcp_transport, packet_source = await asyncio.get_running_loop().create_connection(


### PR DESCRIPTION
This allows calls to be unblocked from waiting for a response when the transport goes away.
The new sink method `on_transport_lost` is optional for sinks. A source should call it when it is terminated.
