### PR TITLE
Update grpcio and pip package versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - pip=20
+  - pip=23
   - python=3.8
   - pip:
     - --editable .[development,documentation,test]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     bt-test-interfaces >= 0.0.2; platform_system!='Emscripten'
     click == 8.1.3; platform_system!='Emscripten'
     cryptography == 39; platform_system!='Emscripten'
-    grpcio == 1.51.1; platform_system!='Emscripten'
+    grpcio == 1.57.0; platform_system!='Emscripten'
     humanize >= 4.6.0; platform_system!='Emscripten'
     libusb1 >= 2.0.1; platform_system!='Emscripten'
     libusb-package == 1.0.26.1; platform_system!='Emscripten'
@@ -81,7 +81,7 @@ test =
     coverage >= 6.4
 development =
     black == 22.10
-    grpcio-tools >= 1.51.1
+    grpcio-tools >= 1.57.0
     invoke >= 1.7.3
     mypy == 1.2.0
     nox >= 2022


### PR DESCRIPTION
The current grpcio version 1.51.1 fails to build on aarch64 based MacOS computers. Update the version of the grpcio and grpcio-tools packages to the latest 1.57.0 version. There are binary wheels available for this version from PyPi for aarch64 MacOS.

Also update the pip version for the Conda environment. It seems a newer version of pip is required to detect and install these wheels.

Testing:

invoke test passes and I can start the bumble-pandora-server successfully.

Fixes #259