### PR TITLE
mypy: ignore false positive errors

### DIFF
--- a/bumble/transport/hci_socket.py
+++ b/bumble/transport/hci_socket.py
@@ -47,9 +47,9 @@ async def open_hci_socket_transport(spec: Optional[str]) -> Transport:
     # Create a raw HCI socket
     try:
         hci_socket = socket.socket(
-            socket.AF_BLUETOOTH,
-            socket.SOCK_RAW | socket.SOCK_NONBLOCK,
-            socket.BTPROTO_HCI,  # type: ignore
+            socket.AF_BLUETOOTH,  # type: ignore[attr-defined]
+            socket.SOCK_RAW | socket.SOCK_NONBLOCK,  # type: ignore[attr-defined]
+            socket.BTPROTO_HCI,  # type: ignore[attr-defined]
         )
     except AttributeError as error:
         # Not supported on this platform
@@ -80,7 +80,7 @@ async def open_hci_socket_transport(spec: Optional[str]) -> Transport:
     bind_address = struct.pack(
         # pylint: disable=no-member
         '<HHH',
-        socket.AF_BLUETOOTH,
+        socket.AF_BLUETOOTH,  # type: ignore[attr-defined]
         adapter_index,
         HCI_CHANNEL_USER,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ development =
     black == 22.10
     grpcio-tools >= 1.57.0
     invoke >= 1.7.3
-    mypy == 1.2.0
+    mypy == 1.5.0
     nox >= 2022
     pylint == 2.15.8
     types-appdirs >= 1.4.3


### PR DESCRIPTION
Not sure why this didn't show up before, but mypy started showing errors that were previously ignored (seems that mypy really needs ignore-error comments on each individual line.