### PR TITLE
Make cryptography a valid dependency for emscripten targets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     bt-test-interfaces >= 0.0.2; platform_system!='Emscripten'
     click == 8.1.3; platform_system!='Emscripten'
     cryptography == 39; platform_system!='Emscripten'
-    # Pyodide has bundles a version of cryptography that is built for wasm, which may not match the
+    # Pyodide bundles a version of cryptography that is built for wasm, which may not match the
     # versions available on PyPI. Relax the version requirement since it's better than being
     # completely unable to import the package in case of version mismatch.
     cryptography >= 39.0; platform_system=='Emscripten'

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     appdirs >= 1.4; platform_system!='Emscripten'
     bt-test-interfaces >= 0.0.2; platform_system!='Emscripten'
     click == 8.1.3; platform_system!='Emscripten'
-    cryptography == 39; platform_system!='Emscripten'
+    cryptography == 39.*
     grpcio == 1.57.0; platform_system!='Emscripten'
     humanize >= 4.6.0; platform_system!='Emscripten'
     libusb1 >= 2.0.1; platform_system!='Emscripten'

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,11 @@ install_requires =
     appdirs >= 1.4; platform_system!='Emscripten'
     bt-test-interfaces >= 0.0.2; platform_system!='Emscripten'
     click == 8.1.3; platform_system!='Emscripten'
-    cryptography == 39.*
+    cryptography == 39; platform_system!='Emscripten'
+    # Pyodide has bundles a version of cryptography that is built for wasm, which may not match the
+    # versions available on PyPI. Relax the version requirement since it's better than being
+    # completely unable to import the package in case of version mismatch.
+    cryptography >= 39.0; platform_system=='Emscripten'
     grpcio == 1.57.0; platform_system!='Emscripten'
     humanize >= 4.6.0; platform_system!='Emscripten'
     libusb1 >= 2.0.1; platform_system!='Emscripten'

--- a/web/bumble.js
+++ b/web/bumble.js
@@ -74,7 +74,6 @@ export async function loadBumble(pyodide, bumblePackage) {
     await pyodide.loadPackage("micropip");
     await pyodide.runPythonAsync(`
         import micropip
-        await micropip.install("cryptography")
         await micropip.install("${bumblePackage}")
         package_list = micropip.list()
         print(package_list)


### PR DESCRIPTION
Since only the special cryptography package bundled with pyodide can be used, relax the version requirement to anything that's version `39.*`.

Fix #284