### PR TITLE
use correct own_address_type when restarting advertising

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -2758,7 +2758,9 @@ class Device(CompositeEventEmitter):
             self.abort_on(
                 'flush',
                 self.start_advertising(
-                    advertising_type=self.advertising_type, auto_restart=True
+                    advertising_type=self.advertising_type,
+                    own_address_type=self.advertising_own_address_type,
+                    auto_restart=True,
                 ),
             )
 


### PR DESCRIPTION
Fix for #299 