### PR TITLE
Log track back in on_packet

### DIFF
--- a/bumble/transport/common.py
+++ b/bumble/transport/common.py
@@ -150,7 +150,7 @@ class PacketParser:
                         try:
                             self.sink.on_packet(bytes(self.packet))
                         except Exception as error:
-                            logger.warning(
+                            logger.exception(
                                 color(f'!!! Exception in on_packet: {error}', 'red')
                             )
                     self.reset()


### PR DESCRIPTION
Many errors are raised in on_packet() callbacks, but currently it only provides a very brief error message.