### PR TITLE
support drivers that can't use reset directly.

### DIFF
--- a/bumble/drivers/__init__.py
+++ b/bumble/drivers/__init__.py
@@ -60,12 +60,23 @@ class Driver(abc.ABC):
 # Functions
 # -----------------------------------------------------------------------------
 async def get_driver_for_host(host):
-    """Probe all known diver classes until one returns a valid instance for a host,
-    or none is found.
+    """Probe diver classes until one returns a valid instance for a host, or none is
+    found.
+    If a "driver" HCI metadata entry is present, only that driver class will be probed.
     """
-    if driver := await rtk.Driver.for_host(host):
-        logger.debug("Instantiated RTK driver")
-        return driver
+    driver_classes = {"rtk": rtk.Driver}
+    if driver_name := host.hci_metadata.get("driver"):
+        # Only probe a single driver
+        probe_list = [driver_name]
+    else:
+        # Probe all drivers
+        probe_list = driver_classes.keys()
+
+    for driver_name in probe_list:
+        logger.debug(f"Probing {driver_name} driver class")
+        if driver := await rtk.Driver.for_host(host):
+            logger.debug(f"Instantiated {driver_name} driver")
+            return driver
 
     return None
 

--- a/bumble/drivers/common.py
+++ b/bumble/drivers/common.py
@@ -1,0 +1,45 @@
+# Copyright 2021-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Common types for drivers.
+"""
+
+# -----------------------------------------------------------------------------
+# Imports
+# -----------------------------------------------------------------------------
+import abc
+
+
+# -----------------------------------------------------------------------------
+# Classes
+# -----------------------------------------------------------------------------
+class Driver(abc.ABC):
+    """Base class for drivers."""
+
+    @staticmethod
+    async def for_host(_host):
+        """Return a driver instance for a host.
+
+        Args:
+            host: Host object for which a driver should be created.
+
+        Returns:
+            A Driver instance if a driver should be instantiated for this host, or
+            None if no driver instance of this class is needed.
+        """
+        return None
+
+    @abc.abstractmethod
+    async def init_controller(self):
+        """Initialize the controller."""

--- a/bumble/drivers/rtk.py
+++ b/bumble/drivers/rtk.py
@@ -470,8 +470,12 @@ class Driver:
             logger.debug("USB metadata not found")
             return False
 
-        vendor_id = host.hci_metadata.get("vendor_id", None)
-        product_id = host.hci_metadata.get("product_id", None)
+        if host.hci_metadata.get('driver') == 'rtk':
+            # Forced driver
+            return True
+
+        vendor_id = host.hci_metadata.get("vendor_id")
+        product_id = host.hci_metadata.get("product_id")
         if vendor_id is None or product_id is None:
             logger.debug("USB metadata not sufficient")
             return False
@@ -486,6 +490,9 @@ class Driver:
 
     @classmethod
     async def driver_info_for_host(cls, host):
+        await host.send_command(HCI_Reset_Command(), check_result=True)
+        host.ready = True  # Needed to let the host know the controller is ready.
+
         response = await host.send_command(
             HCI_Read_Local_Version_Information_Command(), check_result=True
         )

--- a/bumble/drivers/rtk.py
+++ b/bumble/drivers/rtk.py
@@ -41,7 +41,7 @@ from bumble.hci import (
     HCI_Reset_Command,
     HCI_Read_Local_Version_Information_Command,
 )
-
+from bumble.drivers import common
 
 # -----------------------------------------------------------------------------
 # Logging
@@ -285,7 +285,7 @@ class Firmware:
             )
 
 
-class Driver:
+class Driver(common.Driver):
     @dataclass
     class DriverInfo:
         rom: int

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -21,7 +21,7 @@ import collections
 import logging
 import struct
 
-from typing import Optional, TYPE_CHECKING, Dict, Callable, Awaitable, cast
+from typing import Any, Awaitable, Callable, Dict, Optional, Union, cast, TYPE_CHECKING
 
 from bumble.colors import color
 from bumble.l2cap import L2CAP_PDU
@@ -124,7 +124,8 @@ class Connection:
 class Host(AbortableEventEmitter):
     connections: Dict[int, Connection]
     acl_packet_queue: collections.deque[HCI_AclDataPacket]
-    hci_sink: TransportSink
+    hci_sink: Optional[TransportSink] = None
+    hci_metadata: Dict[str, Any]
     long_term_key_provider: Optional[
         Callable[[int, bytes, int], Awaitable[Optional[bytes]]]
     ]
@@ -137,9 +138,8 @@ class Host(AbortableEventEmitter):
     ) -> None:
         super().__init__()
 
-        self.hci_metadata = None
+        self.hci_metadata = {}
         self.ready = False  # True when we can accept incoming packets
-        self.reset_done = False
         self.connections = {}  # Connections, by connection handle
         self.pending_command = None
         self.pending_response = None
@@ -162,10 +162,7 @@ class Host(AbortableEventEmitter):
 
         # Connect to the source and sink if specified
         if controller_source:
-            controller_source.set_packet_sink(self)
-            self.hci_metadata = getattr(
-                controller_source, 'metadata', self.hci_metadata
-            )
+            self.set_packet_source(controller_source)
         if controller_sink:
             self.set_packet_sink(controller_sink)
 
@@ -200,17 +197,21 @@ class Host(AbortableEventEmitter):
             self.ready = False
             await self.flush()
 
-        await self.send_command(HCI_Reset_Command(), check_result=True)
-        self.ready = True
-
         # Instantiate and init a driver for the host if needed.
         # NOTE: we don't keep a reference to the driver here, because we don't
         # currently have a need for the driver later on. But if the driver interface
         # evolves, it may be required, then, to store a reference to the driver in
         # an object property.
+        reset_needed = True
         if driver_factory is not None:
             if driver := await driver_factory(self):
                 await driver.init_controller()
+                reset_needed = False
+
+        # Send a reset command unless a driver has already done so.
+        if reset_needed:
+            await self.send_command(HCI_Reset_Command(), check_result=True)
+            self.ready = True
 
         response = await self.send_command(
             HCI_Read_Local_Supported_Commands_Command(), check_result=True
@@ -313,25 +314,28 @@ class Host(AbortableEventEmitter):
                     )
                 )
 
-        self.reset_done = True
-
     @property
-    def controller(self) -> TransportSink:
+    def controller(self) -> Optional[TransportSink]:
         return self.hci_sink
 
     @controller.setter
-    def controller(self, controller):
+    def controller(self, controller) -> None:
         self.set_packet_sink(controller)
         if controller:
             controller.set_packet_sink(self)
 
-    def set_packet_sink(self, sink: TransportSink) -> None:
+    def set_packet_sink(self, sink: Optional[TransportSink]) -> None:
         self.hci_sink = sink
+
+    def set_packet_source(self, source: TransportSource) -> None:
+        source.set_packet_sink(self)
+        self.hci_metadata = getattr(source, 'metadata', self.hci_metadata)
 
     def send_hci_packet(self, packet: HCI_Packet) -> None:
         if self.snooper:
             self.snooper.snoop(bytes(packet), Snooper.Direction.HOST_TO_CONTROLLER)
-        self.hci_sink.on_packet(bytes(packet))
+        if self.hci_sink:
+            self.hci_sink.on_packet(bytes(packet))
 
     async def send_command(self, command, check_result=False):
         logger.debug(f'{color("### HOST -> CONTROLLER", "blue")}: {command}')

--- a/bumble/transport/__init__.py
+++ b/bumble/transport/__init__.py
@@ -111,75 +111,75 @@ async def _open_transport(scheme: str, spec: Optional[str]) -> Transport:
     if scheme == 'serial' and spec:
         from .serial import open_serial_transport
 
-        return await open_serial_transport(spec[0])
+        return await open_serial_transport(spec)
 
     if scheme == 'udp' and spec:
         from .udp import open_udp_transport
 
-        return await open_udp_transport(spec[0])
+        return await open_udp_transport(spec)
 
     if scheme == 'tcp-client' and spec:
         from .tcp_client import open_tcp_client_transport
 
-        return await open_tcp_client_transport(spec[0])
+        return await open_tcp_client_transport(spec)
 
     if scheme == 'tcp-server' and spec:
         from .tcp_server import open_tcp_server_transport
 
-        return await open_tcp_server_transport(spec[0])
+        return await open_tcp_server_transport(spec)
 
     if scheme == 'ws-client' and spec:
         from .ws_client import open_ws_client_transport
 
-        return await open_ws_client_transport(spec[0])
+        return await open_ws_client_transport(spec)
 
     if scheme == 'ws-server' and spec:
         from .ws_server import open_ws_server_transport
 
-        return await open_ws_server_transport(spec[0])
+        return await open_ws_server_transport(spec)
 
     if scheme == 'pty':
         from .pty import open_pty_transport
 
-        return await open_pty_transport(spec[0] if spec else None)
+        return await open_pty_transport(spec)
 
     if scheme == 'file':
         from .file import open_file_transport
 
         assert spec is not None
-        return await open_file_transport(spec[0])
+        return await open_file_transport(spec)
 
     if scheme == 'vhci':
         from .vhci import open_vhci_transport
 
-        return await open_vhci_transport(spec[0] if spec else None)
+        return await open_vhci_transport(spec)
 
     if scheme == 'hci-socket':
         from .hci_socket import open_hci_socket_transport
 
-        return await open_hci_socket_transport(spec[0] if spec else None)
+        return await open_hci_socket_transport(spec)
 
     if scheme == 'usb':
         from .usb import open_usb_transport
 
-        assert spec is not None
-        return await open_usb_transport(spec[0])
+        assert spec
+        return await open_usb_transport(spec)
 
     if scheme == 'pyusb':
         from .pyusb import open_pyusb_transport
 
-        assert spec is not None
-        return await open_pyusb_transport(spec[0])
+        assert spec
+        return await open_pyusb_transport(spec)
 
     if scheme == 'android-emulator':
         from .android_emulator import open_android_emulator_transport
 
-        return await open_android_emulator_transport(spec[0] if spec else None)
+        return await open_android_emulator_transport(spec)
 
     if scheme == 'android-netsim':
         from .android_netsim import open_android_netsim_transport
 
-        return await open_android_netsim_transport(spec[0] if spec else None)
+        return await open_android_netsim_transport(spec)
 
     raise ValueError('unknown transport scheme')
 

--- a/bumble/transport/android_emulator.py
+++ b/bumble/transport/android_emulator.py
@@ -69,7 +69,7 @@ async def open_android_emulator_transport(spec: Optional[str]) -> Transport:
     mode = 'host'
     server_host = 'localhost'
     server_port = '8554'
-    if spec is not None:
+    if spec:
         params = spec.split(',')
         for param in params:
             if param.startswith('mode='):

--- a/bumble/transport/common.py
+++ b/bumble/transport/common.py
@@ -21,7 +21,7 @@ import struct
 import asyncio
 import logging
 import io
-from typing import ContextManager, Tuple, Optional, Protocol, Dict
+from typing import Any, ContextManager, Tuple, Optional, Protocol, Dict
 
 from bumble import hci
 from bumble.colors import color

--- a/bumble/transport/hci_socket.py
+++ b/bumble/transport/hci_socket.py
@@ -59,10 +59,7 @@ async def open_hci_socket_transport(spec: Optional[str]) -> Transport:
         ) from error
 
     # Compute the adapter index
-    if spec is None:
-        adapter_index = 0
-    else:
-        adapter_index = int(spec)
+    adapter_index = int(spec) if spec else 0
 
     # Bind the socket
     # NOTE: since Python doesn't support binding with the required address format (yet),

--- a/docs/mkdocs/src/drivers/index.md
+++ b/docs/mkdocs/src/drivers/index.md
@@ -5,6 +5,15 @@ Some Bluetooth controllers require a driver to function properly.
 This may include, for instance, loading a Firmware image or patch,
 loading a configuration.
 
+By default, drivers will be automatically probed to determine if they should be
+used with particular HCI controller.
+When the transport for an HCI controller is instantiated from a transport name,
+a driver may also be forced by specifying ``driver=<driver-name>`` in the optional
+metadata portion of the transport name. For example,
+``usb:[driver=-rtk]0`` indicates that the ``rtk`` driver should be used with the
+first USB device, even if a normal probe would not have selected it based on the
+USB vendor ID and product ID.
+
 Drivers included in the module are:
 
   * [Realtek](realtek.md): Loading of Firmware and Config for Realtek USB dongles.

--- a/docs/mkdocs/src/drivers/realtek.md
+++ b/docs/mkdocs/src/drivers/realtek.md
@@ -1,13 +1,16 @@
 REALTEK DRIVER
 ==============
 
-This driver supports loading firmware images and optional config data to 
+This driver supports loading firmware images and optional config data to
 USB dongles with a Realtek chipset.
 A number of USB dongles are supported, but likely not all.
-When using a USB dongle, the USB product ID and manufacturer ID are used
+When using a USB dongle, the USB product ID and vendor ID are used
 to find whether a matching set of firmware image and config data
 is needed for that specific model. If a match exists, the driver will try
 load the firmware image and, if needed, config data.
+Alternatively, the metadata property ``driver=rtk`` may be specified in a transport
+name to force that driver to be used (ex: ``usb:[driver=rtk]0`` instead of just
+``usb:0`` for the first USB device).
 The driver will look for those files by name, in order, in:
 
   * The directory specified by the environment variable `BUMBLE_RTK_FIRMWARE_DIR`


### PR DESCRIPTION
This should allow a driver to interact with a controller, via the `host`, before any command, including RESET is issued.
See the example with the Realtek driver. 
Note that if a driver needs to send a command and receive a response before RESET is performed, it must set `host.ready = True` to allow the inbound packet processing to accept the packet even if no RESET has been done (by default, the host ignores packets from the controller that are received before a RESET).

Also included is a generic way to add HCI metadata to an HCI transport source. Previously, only certain transport sources would set metdata (USB would set `vendor_id` and `product_id`, which the Realtek driver uses to determine if it should try
to load a FW image). Now, a driver can be "forced" for a specific HCI source, when no relevant metadata is available (for 
example, when the controller is only visible via a transport that does not set metadata, like a serial port or TCP socket). 
Any number of metadata `key=value` pairs can be added to a transport name, in square brackets, after the transport type.
Example: `usb:[driver=rtk]0` would "inject" a "driver" metadata entry for the usb transport, which the Realtek driver will see as a request that this driver be activated, even if the `vendor_id` and `product_id` are not present, or don't match the internal allow-list.