### PR TITLE
Support non-directed address generation offload

### DIFF
--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -1993,10 +1993,8 @@ class Manager(EventEmitter):
     ) -> None:
         # Store the keys in the key store
         if self.device.keystore and identity_address is not None:
-            self.device.abort_on(
-                'flush', self.device.update_keys(str(identity_address), keys)
-            )
-
+            # Make sure on_pairing emits after key update.
+            await self.device.update_keys(str(identity_address), keys)
         # Notify the device
         self.device.on_pairing(session.connection, identity_address, keys, session.sc)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ development =
     types-protobuf >= 4.21.0
 avatar =
     pandora-avatar == 0.0.5
-    rootcanal == 1.4.0 ; python_version>='3.10'
+    rootcanal == 1.6.0 ; python_version>='3.10'
 documentation =
     mkdocs >= 1.4.0
     mkdocs-material >= 8.5.6


### PR DESCRIPTION
Address generation offloading uses peer address as an entry of IRK, even in non-directed usage. By adding an empty entry containing local IRK to controller resolving list, controllers are able to generate RPA without pairing.