### PR TITLE
support async read/write for characteristic values

### DIFF
--- a/apps/console.py
+++ b/apps/console.py
@@ -777,7 +777,7 @@ class ConsoleApp:
                 if not service:
                     continue
                 values = [
-                    attribute.read_value(connection)
+                    await attribute.read_value(connection)
                     for connection in self.device.connections.values()
                 ]
                 if not values:
@@ -796,11 +796,11 @@ class ConsoleApp:
                 if not characteristic:
                     continue
                 values = [
-                    attribute.read_value(connection)
+                    await attribute.read_value(connection)
                     for connection in self.device.connections.values()
                 ]
                 if not values:
-                    values = [attribute.read_value(None)]
+                    values = [await attribute.read_value(None)]
 
                 # TODO: future optimization: convert CCCD value to human readable string
 
@@ -944,7 +944,7 @@ class ConsoleApp:
 
         # send data to any subscribers
         if isinstance(attribute, Characteristic):
-            attribute.write_value(None, value)
+            await attribute.write_value(None, value)
             if attribute.has_properties(Characteristic.NOTIFY):
                 await self.device.gatt_server.notify_subscribers(attribute)
             if attribute.has_properties(Characteristic.INDICATE):

--- a/bumble/profiles/asha_service.py
+++ b/bumble/profiles/asha_service.py
@@ -18,7 +18,7 @@
 # -----------------------------------------------------------------------------
 import struct
 import logging
-from typing import List
+from typing import List, Optional
 
 from bumble import l2cap
 from ..core import AdvertisingData
@@ -67,7 +67,7 @@ class AshaService(TemplateService):
             self.emit('volume', connection, value[0])
 
         # Handler for audio control commands
-        def on_audio_control_point_write(connection: Connection, value):
+        def on_audio_control_point_write(connection: Optional[Connection], value):
             logger.info(f'--- AUDIO CONTROL POINT Write:{value.hex()}')
             opcode = value[0]
             if opcode == AshaService.OPCODE_START:

--- a/bumble/profiles/bap.py
+++ b/bumble/profiles/bap.py
@@ -114,7 +114,7 @@ class SamplingFrequency(enum.IntEnum):
     '''Bluetooth Assigned Numbers, Section 6.12.5.1 - Sampling Frequency'''
 
     # fmt: off
-    FREQ_8000    = 0x01 
+    FREQ_8000    = 0x01
     FREQ_11025   = 0x02
     FREQ_16000   = 0x03
     FREQ_22050   = 0x04
@@ -430,7 +430,7 @@ class AseResponseCode(enum.IntEnum):
     REJECTED_METADATA                           = 0x0B
     INVALID_METADATA                            = 0x0C
     INSUFFICIENT_RESOURCES                      = 0x0D
-    UNSPECIFIED_ERROR                           = 0x0E    
+    UNSPECIFIED_ERROR                           = 0x0E
 
 
 class AseReasonCode(enum.IntEnum):
@@ -1066,7 +1066,7 @@ class AseStateMachine(gatt.Characteristic):
         # Readonly. Do nothing in the setter.
         pass
 
-    def on_read(self, _: device.Connection) -> bytes:
+    def on_read(self, _: Optional[device.Connection]) -> bytes:
         return self.value
 
     def __str__(self) -> str:

--- a/bumble/profiles/csip.py
+++ b/bumble/profiles/csip.py
@@ -152,7 +152,7 @@ class CoordinatedSetIdentificationService(gatt.TemplateService):
 
         super().__init__(characteristics)
 
-    def on_sirk_read(self, _connection: device.Connection) -> bytes:
+    def on_sirk_read(self, _connection: Optional[device.Connection]) -> bytes:
         if self.set_identity_resolving_key_type == SirkType.PLAINTEXT:
             return bytes([SirkType.PLAINTEXT]) + self.set_identity_resolving_key
         else:

--- a/bumble/utils.py
+++ b/bumble/utils.py
@@ -280,17 +280,14 @@ class AsyncRunner:
             def wrapper(*args, **kwargs):
                 coroutine = func(*args, **kwargs)
                 if queue is None:
-                    # Create a task to run the coroutine
+                    # Spawn the coroutine as a task
                     async def run():
                         try:
                             await coroutine
                         except Exception:
-                            logger.warning(
-                                f'{color("!!! Exception in wrapper:", "red")} '
-                                f'{traceback.format_exc()}'
-                            )
+                            logger.exception(color("!!! Exception in wrapper:", "red"))
 
-                    asyncio.create_task(run())
+                    AsyncRunner.spawn(run())
                 else:
                     # Queue the coroutine to be awaited by the work queue
                     queue.enqueue(coroutine)

--- a/tests/bap_test.py
+++ b/tests/bap_test.py
@@ -48,7 +48,8 @@ from bumble.profiles.bap import (
     PublishedAudioCapabilitiesService,
     PublishedAudioCapabilitiesServiceProxy,
 )
-from .test_utils import TwoDevices
+from tests.test_utils import TwoDevices
+
 
 # -----------------------------------------------------------------------------
 # Logging


### PR DESCRIPTION
This allows the `read` and/or `write` functions of `CharacteristicValue` to be async (or be sync functions that return an awaitable), without requiring them to be. The server will automatically adapt to both types.
