### PR TITLE
update credits even without a sink

### DIFF
--- a/bumble/helpers.py
+++ b/bumble/helpers.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, MutableMapping
-from typing import cast, Any
+from typing import cast, Any, Optional
 import logging
 
 from bumble import avdtp
@@ -69,7 +69,7 @@ PSM_NAMES = {
 class PacketTracer:
     class AclStream:
         psms: MutableMapping[int, int]
-        peer: PacketTracer.AclStream
+        peer: Optional[PacketTracer.AclStream]
         avdtp_assemblers: MutableMapping[int, avdtp.MessageAssembler]
 
         def __init__(self, analyzer: PacketTracer.Analyzer) -> None:
@@ -77,6 +77,7 @@ class PacketTracer:
             self.packet_assembler = HCI_AclDataPacketAssembler(self.on_acl_pdu)
             self.avdtp_assemblers = {}  # AVDTP assemblers, by source_cid
             self.psms = {}  # PSM, by source_cid
+            self.peer = None
 
         # pylint: disable=too-many-nested-blocks
         def on_acl_pdu(self, pdu: bytes) -> None:

--- a/bumble/rfcomm.py
+++ b/bumble/rfcomm.py
@@ -538,7 +538,7 @@ class DLC(EventEmitter):
             f'[{self.dlci}] {len(data)} bytes, '
             f'rx_credits={self.rx_credits}: {data.hex()}'
         )
-        if len(data):
+        if data:
             if self.sink:
                 self.sink(data)  # pylint: disable=not-callable
 

--- a/bumble/rfcomm.py
+++ b/bumble/rfcomm.py
@@ -538,8 +538,9 @@ class DLC(EventEmitter):
             f'[{self.dlci}] {len(data)} bytes, '
             f'rx_credits={self.rx_credits}: {data.hex()}'
         )
-        if len(data) and self.sink:
-            self.sink(data)  # pylint: disable=not-callable
+        if len(data):
+            if self.sink:
+                self.sink(data)  # pylint: disable=not-callable
 
             # Update the credits
             if self.rx_credits > 0:

--- a/extras/android/RemoteHCI/app/build.gradle.kts
+++ b/extras/android/RemoteHCI/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.github.google.bumble.remotehci"
-        minSdk = 26
+        minSdk = 29
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"

--- a/extras/android/RemoteHCI/app/src/main/java/com/github/google/bumble/remotehci/HciHal.java
+++ b/extras/android/RemoteHCI/app/src/main/java/com/github/google/bumble/remotehci/HciHal.java
@@ -4,6 +4,7 @@ import android.hardware.bluetooth.V1_0.Status;
 import android.os.IBinder;
 import android.os.RemoteException;
 import android.os.ServiceManager;
+import android.os.Trace;
 import android.util.Log;
 
 import java.util.ArrayList;
@@ -53,6 +54,7 @@ class HciHidlHal extends android.hardware.bluetooth.V1_0.IBluetoothHciCallbacks.
     private final android.hardware.bluetooth.V1_0.IBluetoothHci mHciService;
     private final HciHalCallback mHciCallbacks;
     private int mInitializationStatus = -1;
+    private final boolean mTracingEnabled = Trace.isEnabled();
 
 
     public static HciHidlHal create(HciHalCallback hciCallbacks) {
@@ -89,6 +91,7 @@ class HciHidlHal extends android.hardware.bluetooth.V1_0.IBluetoothHciCallbacks.
         }
 
         // Map the status code.
+        Log.d(TAG, "Initialization status = " + mInitializationStatus);
         switch (mInitializationStatus) {
             case android.hardware.bluetooth.V1_0.Status.SUCCESS:
                 return Status.SUCCESS;
@@ -108,6 +111,10 @@ class HciHidlHal extends android.hardware.bluetooth.V1_0.IBluetoothHciCallbacks.
     public void sendPacket(HciPacket.Type type, byte[] packet) {
         ArrayList<Byte> data = HciPacket.byteArrayToList(packet);
 
+        if (mTracingEnabled) {
+            Trace.beginAsyncSection("SEND_PACKET_TO_HAL", 1);
+        }
+
         try {
             switch (type) {
                 case COMMAND:
@@ -124,6 +131,10 @@ class HciHidlHal extends android.hardware.bluetooth.V1_0.IBluetoothHciCallbacks.
             }
         } catch (RemoteException error) {
             Log.w(TAG, "failed to forward packet: " + error);
+        }
+
+        if (mTracingEnabled) {
+            Trace.endAsyncSection("SEND_PACKET_TO_HAL", 1);
         }
     }
 
@@ -157,6 +168,7 @@ class HciAidlHal extends android.hardware.bluetooth.IBluetoothHciCallbacks.Stub 
     private final android.hardware.bluetooth.IBluetoothHci mHciService;
     private final HciHalCallback mHciCallbacks;
     private int mInitializationStatus = android.hardware.bluetooth.Status.SUCCESS;
+    private final boolean mTracingEnabled = Trace.isEnabled();
 
     public static HciAidlHal create(HciHalCallback hciCallbacks) {
         IBinder binder = ServiceManager.getService("android.hardware.bluetooth.IBluetoothHci/default");
@@ -187,6 +199,7 @@ class HciAidlHal extends android.hardware.bluetooth.IBluetoothHciCallbacks.Stub 
         }
 
         // Map the status code.
+        Log.d(TAG, "Initialization status = " + mInitializationStatus);
         switch (mInitializationStatus) {
             case android.hardware.bluetooth.Status.SUCCESS:
                 return Status.SUCCESS;
@@ -208,6 +221,10 @@ class HciAidlHal extends android.hardware.bluetooth.IBluetoothHciCallbacks.Stub 
     // HciHal methods.
     @Override
     public void sendPacket(HciPacket.Type type, byte[] packet) {
+        if (mTracingEnabled) {
+            Trace.beginAsyncSection("SEND_PACKET_TO_HAL", 1);
+        }
+
         try {
             switch (type) {
                 case COMMAND:
@@ -228,6 +245,10 @@ class HciAidlHal extends android.hardware.bluetooth.IBluetoothHciCallbacks.Stub 
             }
         } catch (RemoteException error) {
             Log.w(TAG, "failed to forward packet: " + error);
+        }
+
+        if (mTracingEnabled) {
+            Trace.endAsyncSection("SEND_PACKET_TO_HAL", 1);
         }
     }
 


### PR DESCRIPTION
Even if the RFComm session has no sink (not very useful, but could happen in a test), we still need to update the credits.