### PR TITLE
add rfcomm options and fix l2cap mtu negotiation

### DIFF
--- a/bumble/avdtp.py
+++ b/bumble/avdtp.py
@@ -1470,10 +1470,10 @@ class Protocol(EventEmitter):
             f'[{transaction_label}] {message}'
         )
         max_fragment_size = (
-            self.l2cap_channel.mtu - 3
+            self.l2cap_channel.peer_mtu - 3
         )  # Enough space for a 3-byte start packet header
         payload = message.payload
-        if len(payload) + 2 <= self.l2cap_channel.mtu:
+        if len(payload) + 2 <= self.l2cap_channel.peer_mtu:
             # Fits in a single packet
             packet_type = self.PacketType.SINGLE_PACKET
         else:

--- a/bumble/hid.py
+++ b/bumble/hid.py
@@ -416,7 +416,7 @@ class Device(HID):
             data = bytearray()
             data.append(report_id)
             data.extend(ret.data)
-            if len(data) < self.l2cap_ctrl_channel.mtu:  # type: ignore[union-attr]
+            if len(data) < self.l2cap_ctrl_channel.peer_mtu:  # type: ignore[union-attr]
                 self.send_control_data(report_type=report_type, data=data)
             else:
                 self.send_handshake_message(Message.Handshake.ERR_INVALID_PARAMETER)

--- a/examples/run_a2dp_source.py
+++ b/examples/run_a2dp_source.py
@@ -74,7 +74,7 @@ def codec_capabilities():
 # -----------------------------------------------------------------------------
 def on_avdtp_connection(read_function, protocol):
     packet_source = SbcPacketSource(
-        read_function, protocol.l2cap_channel.mtu, codec_capabilities()
+        read_function, protocol.l2cap_channel.peer_mtu, codec_capabilities()
     )
     packet_pump = MediaPacketPump(packet_source.packets)
     protocol.add_source(packet_source.codec_capabilities, packet_pump)
@@ -98,7 +98,7 @@ async def stream_packets(read_function, protocol):
 
     # Stream the packets
     packet_source = SbcPacketSource(
-        read_function, protocol.l2cap_channel.mtu, codec_capabilities()
+        read_function, protocol.l2cap_channel.peer_mtu, codec_capabilities()
     )
     packet_pump = MediaPacketPump(packet_source.packets)
     source = protocol.add_source(packet_source.codec_capabilities, packet_pump)

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     pyserial-asyncio >= 0.5; platform_system!='Emscripten'
     pyserial >= 3.5; platform_system!='Emscripten'
     pyusb >= 1.2; platform_system!='Emscripten'
-    websockets >= 8.1; platform_system!='Emscripten'
+    websockets >= 12.0; platform_system!='Emscripten'
 
 [options.entry_points]
 console_scripts =

--- a/tests/rfcomm_test.py
+++ b/tests/rfcomm_test.py
@@ -17,6 +17,7 @@
 # -----------------------------------------------------------------------------
 import asyncio
 import pytest
+from typing import List
 
 from . import test_utils
 from bumble import core
@@ -59,17 +60,18 @@ def test_frames():
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_basic_connection():
+async def test_basic_connection() -> None:
     devices = test_utils.TwoDevices()
     await devices.setup_connection()
 
     accept_future: asyncio.Future[DLC] = asyncio.get_running_loop().create_future()
     channel = Server(devices[0]).listen(acceptor=accept_future.set_result)
 
+    assert devices.connections[1]
     multiplexer = await Client(devices.connections[1]).start()
     dlcs = await asyncio.gather(accept_future, multiplexer.open_dlc(channel))
 
-    queues = [asyncio.Queue(), asyncio.Queue()]
+    queues: List[asyncio.Queue] = [asyncio.Queue(), asyncio.Queue()]
     for dlc, queue in zip(dlcs, queues):
         dlc.sink = queue.put_nowait
 


### PR DESCRIPTION
This adds options to the Bench app to control RFCOMM parameters.
Also included is a small fix for MTU negotiation in L2CAP (keeping track of both the local MTU and the peer MTU)