### PR TITLE
Bump Rust to 1.76.0

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        rust-version: [ "1.70.0", "stable" ]
+        rust-version: [ "1.76.0", "stable" ]
       fail-fast: false
     steps:
       - name: Check out from Git

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/crate/bumble"
 authors = ["Marshall Pierce <marshallpierce@google.com>"]
 keywords = ["bluetooth", "ble"]
 categories = ["api-bindings", "network-programming"]
-rust-version = "1.70.0"
+rust-version = "1.76.0"
 
 # https://github.com/frewsxcv/cargo-all-features#options
 [package.metadata.cargo-all-features]


### PR DESCRIPTION
```
error: failed to compile `cargo-all-features v1.10.0`, intermediate artifacts can be found at `/tmp/cargo-installshCmAG`

Caused by:
  package `clap v4.5.1` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
  Try re-running cargo install with `--locked`

```