### PR TITLE
fix intel driver probe

### DIFF
--- a/bumble/drivers/intel.py
+++ b/bumble/drivers/intel.py
@@ -53,8 +53,12 @@ class Driver(common.Driver):
         self.host = host
 
     @classmethod
-    async def for_host(cls, host, force=False):  # type: ignore
-        return cls(host)
+    async def for_host(cls, host):  # type: ignore
+        # Only instantiate this driver if explicitly selected
+        if host.hci_metadata.get("driver") == "intel":
+            return cls(host)
+
+        return None
 
     async def init_controller(self):
         self.host.ready = True

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -498,7 +498,7 @@ class Host(AbortableEventEmitter):
     def controller(self, controller) -> None:
         self.set_packet_sink(controller)
         if controller:
-            controller.set_packet_sink(self)
+            self.set_packet_source(controller)
 
     def set_packet_sink(self, sink: Optional[TransportSink]) -> None:
         self.hci_sink = sink

--- a/docs/mkdocs/src/drivers/index.md
+++ b/docs/mkdocs/src/drivers/index.md
@@ -10,7 +10,7 @@ used with particular HCI controller.
 When the transport for an HCI controller is instantiated from a transport name,
 a driver may also be forced by specifying ``driver=<driver-name>`` in the optional
 metadata portion of the transport name. For example,
-``usb:[driver=-rtk]0`` indicates that the ``rtk`` driver should be used with the
+``usb:[driver=rtk]0`` indicates that the ``rtk`` driver should be used with the
 first USB device, even if a normal probe would not have selected it based on the
 USB vendor ID and product ID.
 


### PR DESCRIPTION
An earlier merge of the driver broke the functionality for most users as it would always instantiate the driver even when not explicitly selected, and therefore send a vendor HCI command even to non-intel controllers.