### PR TITLE
update some dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,17 +34,17 @@ install_requires =
     aiohttp ~= 3.8; platform_system!='Emscripten'
     appdirs >= 1.4; platform_system!='Emscripten'
     bt-test-interfaces >= 0.0.2; platform_system!='Emscripten'
-    click == 8.1.3; platform_system!='Emscripten'
+    click >= 8.1.3; platform_system!='Emscripten'
     cryptography == 39; platform_system!='Emscripten'
     # Pyodide bundles a version of cryptography that is built for wasm, which may not match the
     # versions available on PyPI. Relax the version requirement since it's better than being
     # completely unable to import the package in case of version mismatch.
     cryptography >= 39.0; platform_system=='Emscripten'
-    grpcio == 1.57.0; platform_system!='Emscripten'
+    grpcio >= 1.62.1; platform_system!='Emscripten'
     humanize >= 4.6.0; platform_system!='Emscripten'
     libusb1 >= 2.0.1; platform_system!='Emscripten'
     libusb-package == 1.0.26.1; platform_system!='Emscripten'
-    platformdirs == 3.10.0; platform_system!='Emscripten'
+    platformdirs >= 3.10.0; platform_system!='Emscripten'
     prompt_toolkit >= 3.0.16; platform_system!='Emscripten'
     prettytable >= 3.6.0; platform_system!='Emscripten'
     protobuf >= 3.12.4; platform_system!='Emscripten'
@@ -83,12 +83,12 @@ build =
     build >= 0.7
 test =
     pytest >= 8.0
-    pytest-asyncio == 0.21.1
+    pytest-asyncio >= 0.21.1
     pytest-html >= 3.2.0
     coverage >= 6.4
 development =
     black == 24.3
-    grpcio-tools >= 1.57.0
+    grpcio-tools >= 1.62.1
     invoke >= 1.7.3
     mypy == 1.8.0
     nox >= 2022

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,7 +98,7 @@ development =
     types-invoke >= 1.7.3
     types-protobuf >= 4.21.0
 avatar =
-    pandora-avatar == 0.0.8
+    pandora-avatar == 0.0.9
     rootcanal == 1.10.0 ; python_version>='3.10'
 documentation =
     mkdocs >= 1.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 install_requires =
     aiohttp ~= 3.8; platform_system!='Emscripten'
     appdirs >= 1.4; platform_system!='Emscripten'
-    bt-test-interfaces >= 0.0.2; platform_system!='Emscripten'
+    bt-test-interfaces >= 0.0.6; platform_system!='Emscripten'
     click >= 8.1.3; platform_system!='Emscripten'
     cryptography == 39; platform_system!='Emscripten'
     # Pyodide bundles a version of cryptography that is built for wasm, which may not match the
@@ -99,7 +99,7 @@ development =
     types-protobuf >= 4.21.0
 avatar =
     pandora-avatar == 0.0.8
-    rootcanal == 1.9.0 ; python_version>='3.10'
+    rootcanal == 1.10.0 ; python_version>='3.10'
 documentation =
     mkdocs >= 1.4.0
     mkdocs-material >= 8.5.6


### PR DESCRIPTION
Python 3.12 on an Apple Silicon mac had trouble installing grpcio. With this update, it works.