### PR TITLE
delay creation of runner object

### DIFF
--- a/apps/bench.py
+++ b/apps/bench.py
@@ -1064,9 +1064,9 @@ class Central(Connection.Listener):
 
             if self.phy not in (None, HCI_LE_1M_PHY):
                 # Add an connections parameters entry for this PHY.
-                self.connection_parameter_preferences[self.phy] = (
-                    connection_parameter_preferences
-                )
+                self.connection_parameter_preferences[
+                    self.phy
+                ] = connection_parameter_preferences
         else:
             self.connection_parameter_preferences = None
 


### PR DESCRIPTION
On some versions of Python, the Event object created in the Central and Peripheral class initializers is called before the main asyncio loop is created, leading to an exception.
This moves the instantiation of the object into a local async function, which solves the problem.