### PR TITLE
fix #461

### DIFF
--- a/bumble/a2dp.py
+++ b/bumble/a2dp.py
@@ -652,7 +652,9 @@ class SbcPacketSource:
 
                     # Prepare for next packets
                     sequence_number += 1
+                    sequence_number &= 0xFFFF
                     timestamp += sum((frame.sample_count for frame in frames))
+                    timestamp &= 0xFFFFFFFF
                     frames = [frame]
                     frames_size = len(frame.payload)
                 else:

--- a/bumble/avdtp.py
+++ b/bumble/avdtp.py
@@ -325,8 +325,8 @@ class MediaPacket:
         self.padding = padding
         self.extension = extension
         self.marker = marker
-        self.sequence_number = sequence_number
-        self.timestamp = timestamp
+        self.sequence_number = sequence_number & 0xFFFF
+        self.timestamp = timestamp & 0xFFFFFFFF
         self.ssrc = ssrc
         self.csrc_list = csrc_list
         self.payload_type = payload_type
@@ -341,7 +341,12 @@ class MediaPacket:
                 | len(self.csrc_list),
                 self.marker << 7 | self.payload_type,
             ]
-        ) + struct.pack('>HII', self.sequence_number, self.timestamp, self.ssrc)
+        ) + struct.pack(
+            '>HII',
+            self.sequence_number,
+            self.timestamp,
+            self.ssrc,
+        )
         for csrc in self.csrc_list:
             header += struct.pack('>I', csrc)
         return header + self.payload


### PR DESCRIPTION
Some fields in RTP packet headers have limited ranges. This clamps the values at construction time.