### PR TITLE
update protobuf dep and make pandora install optional

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ".[build,test,development]"
+        python -m pip install ".[build,test,development,pandora]"
     - name: Check
       run: |
         invoke project.pre-commit

--- a/.github/workflows/python-avatar.yml
+++ b/.github/workflows/python-avatar.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[avatar]
+          python -m pip install .[avatar,pandora]
       - name: Rootcanal
         run: nohup python -m rootcanal > rootcanal.log &
       - name: Test

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ include_package_data = True
 install_requires =
     aiohttp ~= 3.8; platform_system!='Emscripten'
     appdirs >= 1.4; platform_system!='Emscripten'
-    bt-test-interfaces >= 0.0.6; platform_system!='Emscripten'
     click >= 8.1.3; platform_system!='Emscripten'
     cryptography == 39; platform_system!='Emscripten'
     # Pyodide bundles a version of cryptography that is built for wasm, which may not match the
@@ -47,7 +46,7 @@ install_requires =
     platformdirs >= 3.10.0; platform_system!='Emscripten'
     prompt_toolkit >= 3.0.16; platform_system!='Emscripten'
     prettytable >= 3.6.0; platform_system!='Emscripten'
-    protobuf >= 3.12.4; platform_system!='Emscripten'
+    protobuf >= 4.24.2; platform_system!='Emscripten'
     pyee >= 8.2.2
     pyserial-asyncio >= 0.5; platform_system!='Emscripten'
     pyserial >= 3.5; platform_system!='Emscripten'
@@ -100,6 +99,8 @@ development =
 avatar =
     pandora-avatar == 0.0.9
     rootcanal == 1.10.0 ; python_version>='3.10'
+pandora =
+    bt-test-interfaces >= 0.0.6
 documentation =
     mkdocs >= 1.4.0
     mkdocs-material >= 8.5.6


### PR DESCRIPTION
Address #471
This makes it easier to manage cross-package dependencies.
Users of pandora now will need to explicitly specify the `[pandora]` extra-require when installing.