### PR TITLE
quick fix: revert to protobuf 3.12.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     platformdirs >= 3.10.0; platform_system!='Emscripten'
     prompt_toolkit >= 3.0.16; platform_system!='Emscripten'
     prettytable >= 3.6.0; platform_system!='Emscripten'
-    protobuf >= 4.24.2; platform_system!='Emscripten'
+    protobuf >= 3.12.4; platform_system!='Emscripten'
     pyee >= 8.2.2
     pyserial-asyncio >= 0.5; platform_system!='Emscripten'
     pyserial >= 3.5; platform_system!='Emscripten'


### PR DESCRIPTION
The upgrade to 4.x wasn't really needed, and breaks some users.