### PR TITLE
RFCOMM: Handle packets received before DLC sink set

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,8 @@
 # Imports
 # -----------------------------------------------------------------------------
 import asyncio
-from typing import List, Optional
+from typing import List, Optional, Type
+from typing_extensions import Self
 
 from bumble.controller import Controller
 from bumble.link import LocalLink
@@ -80,6 +81,12 @@ class TwoDevices:
 
     def __getitem__(self, index: int) -> Device:
         return self.devices[index]
+
+    @classmethod
+    async def create_with_connection(cls: Type[Self]) -> Self:
+        devices = cls()
+        await devices.setup_connection()
+        return devices
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This race condition is not common since usually the initiator (no matter it's an L2CAP or RFCOMM channel) should send the first packet. However, in HFP, if it is AG opening the channel, AG cannot send the first packet, and HF may send AT+BRSF too quick that `open_dlc()` haven't returned yet.