### PR TITLE
Fix: Preserve transport metadata

### DIFF
--- a/bumble/transport/common.py
+++ b/bumble/transport/common.py
@@ -425,6 +425,10 @@ class SnoopingTransport(Transport):
     class Source:
         sink: TransportSink
 
+        @property
+        def metadata(self) -> dict[str, Any]:
+            return getattr(self.source, 'metadata', {})
+
         def __init__(self, source: TransportSource, snooper: Snooper):
             self.source = source
             self.snooper = snooper


### PR DESCRIPTION
Preserve transport metadata when wrapping with SnoopingTransport