### PR TITLE
[Bug] Edimax BLE Dongle Fails After Teardown and Re-Instantiation

### DIFF
--- a/bumble/drivers/rtk.py
+++ b/bumble/drivers/rtk.py
@@ -296,6 +296,8 @@ class Driver(common.Driver):
         fw_name: str = ""
         config_name: str = ""
 
+    POST_RESET_DELAY = 0.2
+
     DRIVER_INFOS = [
         # 8723A
         DriverInfo(
@@ -490,12 +492,24 @@ class Driver(common.Driver):
 
     @classmethod
     async def driver_info_for_host(cls, host):
-        await host.send_command(HCI_Reset_Command(), check_result=True)
-        host.ready = True  # Needed to let the host know the controller is ready.
+        try:
+            await host.send_command(
+                HCI_Reset_Command(), check_result=True, timeout=cls.POST_RESET_DELAY
+            )
+            host.ready = True  # Needed to let the host know the controller is ready.
+        except asyncio.exceptions.TimeoutError:
+            logger.warning("timeout waiting for hci reset, retrying")
+            if host.hci_source and hasattr(host.hci_source, "parser"):
+                host.hci_source.parser.reset()
+            await host.send_command(HCI_Reset_Command(), check_result=True)
+            host.ready = True
 
-        response = await host.send_command(
-            HCI_Read_Local_Version_Information_Command(), check_result=True
-        )
+        command = HCI_Read_Local_Version_Information_Command()
+        response = await host.send_command(command, check_result=True)
+        if response.command_opcode != command.op_code:
+            logger.error("failed to probe local version information")
+            return None
+
         local_version = response.return_parameters
 
         logger.debug(

--- a/bumble/drivers/rtk.py
+++ b/bumble/drivers/rtk.py
@@ -494,7 +494,7 @@ class Driver(common.Driver):
     async def driver_info_for_host(cls, host):
         try:
             await host.send_command(
-                HCI_Reset_Command(), check_result=True, timeout=cls.POST_RESET_DELAY
+                HCI_Reset_Command(), check_result=True, response_timeout=cls.POST_RESET_DELAY
             )
             host.ready = True  # Needed to let the host know the controller is ready.
         except asyncio.exceptions.TimeoutError:

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -152,6 +152,7 @@ class Host(AbortableEventEmitter):
     acl_packet_queue: Optional[AclPacketQueue] = None
     le_acl_packet_queue: Optional[AclPacketQueue] = None
     hci_sink: Optional[TransportSink] = None
+    hci_source: Optional[TransportSource] = None
     hci_metadata: Dict[str, Any]
     long_term_key_provider: Optional[
         Callable[[int, bytes, int], Awaitable[Optional[bytes]]]
@@ -506,6 +507,7 @@ class Host(AbortableEventEmitter):
     def set_packet_source(self, source: TransportSource) -> None:
         source.set_packet_sink(self)
         self.hci_metadata = getattr(source, 'metadata', self.hci_metadata)
+        self.hci_source = source
 
     def send_hci_packet(self, packet: hci.HCI_Packet) -> None:
         logger.debug(f'{color("### HOST -> CONTROLLER", "blue")}: {packet}')
@@ -514,7 +516,7 @@ class Host(AbortableEventEmitter):
         if self.hci_sink:
             self.hci_sink.on_packet(bytes(packet))
 
-    async def send_command(self, command, check_result=False):
+    async def send_command(self, command, check_result=False, timeout=None):
         # Wait until we can send (only one pending command at a time)
         async with self.command_semaphore:
             assert self.pending_command is None
@@ -526,7 +528,8 @@ class Host(AbortableEventEmitter):
 
             try:
                 self.send_hci_packet(command)
-                response = await self.pending_response
+                await asyncio.wait_for(self.pending_response, timeout=timeout)
+                response = self.pending_response.result()
 
                 # Check the return parameters if required
                 if check_result:
@@ -625,14 +628,19 @@ class Host(AbortableEventEmitter):
 
     # Packet Sink protocol (packets coming from the controller via HCI)
     def on_packet(self, packet: bytes) -> None:
-        hci_packet = hci.HCI_Packet.from_bytes(packet)
+        try:
+            hci_packet = hci.HCI_Packet.from_bytes(packet)
+        except Exception as error:
+            logger.warning(f'!!! error parsing packet from bytes: {error}')
+            return
+
         if self.ready or (
             isinstance(hci_packet, hci.HCI_Command_Complete_Event)
             and hci_packet.command_opcode == hci.HCI_RESET_COMMAND
         ):
             self.on_hci_packet(hci_packet)
         else:
-            logger.debug('reset not done, ignoring packet from controller')
+            logger.debug(f'reset not done, ignoring packet from controller: {hci_packet}')
 
     def on_transport_lost(self):
         # Called by the source when the transport has been lost.

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -516,7 +516,7 @@ class Host(AbortableEventEmitter):
         if self.hci_sink:
             self.hci_sink.on_packet(bytes(packet))
 
-    async def send_command(self, command, check_result=False, timeout=None):
+    async def send_command(self, command, check_result=False, response_timeout: Optional[int] = None):
         # Wait until we can send (only one pending command at a time)
         async with self.command_semaphore:
             assert self.pending_command is None
@@ -528,7 +528,7 @@ class Host(AbortableEventEmitter):
 
             try:
                 self.send_hci_packet(command)
-                await asyncio.wait_for(self.pending_response, timeout=timeout)
+                await asyncio.wait_for(self.pending_response, timeout=response_timeout)
                 response = self.pending_response.result()
 
                 # Check the return parameters if required

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -640,7 +640,9 @@ class Host(AbortableEventEmitter):
         ):
             self.on_hci_packet(hci_packet)
         else:
-            logger.debug(f'reset not done, ignoring packet from controller: {hci_packet}')
+            logger.debug(
+                f'reset not done, ignoring packet from controller: {hci_packet}'
+            )
 
     def on_transport_lost(self):
         # Called by the source when the transport has been lost.

--- a/bumble/transport/common.py
+++ b/bumble/transport/common.py
@@ -132,7 +132,9 @@ class PacketParser:
                         packet_type
                     ) or self.extended_packet_info.get(packet_type)
                     if self.packet_info is None:
-                        raise ValueError(f'invalid packet type {packet_type}')
+                        logger.warning(f'ignoring invalid packet type: {packet_type}')
+                        self.reset()
+                        break
                     self.state = PacketParser.NEED_LENGTH
                     self.bytes_needed = self.packet_info[0] + self.packet_info[1]
                 elif self.state == PacketParser.NEED_LENGTH:

--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -126,6 +126,7 @@ async def open_usb_transport(spec: str) -> Transport:
         def on_packet(self, packet):
             # Ignore packets if we're closed
             if self.closed:
+                logger.warning('ignoring packet, closed')
                 return
 
             if len(packet) == 0:
@@ -280,7 +281,12 @@ async def open_usb_transport(spec: str) -> Transport:
                     packet = await self.queue.get()
                 except asyncio.CancelledError:
                     return
-                self.parser.feed_data(packet)
+                try:
+                    self.parser.feed_data(packet)
+                except Exception as error:
+                    logger.warning(
+                        color(f'!!! error feeding data: {error}', 'red')
+                    )
 
         def close(self):
             self.closed = True

--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -284,9 +284,7 @@ async def open_usb_transport(spec: str) -> Transport:
                 try:
                     self.parser.feed_data(packet)
                 except Exception as error:
-                    logger.warning(
-                        color(f'!!! error feeding data: {error}', 'red')
-                    )
+                    logger.warning(color(f'!!! error feeding data: {error}', 'red'))
 
         def close(self):
             self.closed = True

--- a/tests/transport_test.py
+++ b/tests/transport_test.py
@@ -62,11 +62,10 @@ def test_parser_extensions():
     except ValueError:
         exception_thrown = True
 
-    assert exception_thrown
+    assert not exception_thrown
 
     # Now add a custom info
     parser.extended_packet_info[0x77] = (1, 1, 'B')
-    parser.reset()
     parser.feed_data(bytes([0x77, 0x00, 0x02, 0x01, 0x02]))
     assert len(sink.packets) == 1
 

--- a/tests/transport_test.py
+++ b/tests/transport_test.py
@@ -55,7 +55,8 @@ def test_parser_extensions():
     sink = Sink()
     parser = PacketParser(sink)
 
-    # Check that an exception is thrown for an unknown type
+    # Check that an exception is not thrown for an unknown type; instead the
+    # parser should be reset.
     try:
         parser.feed_data(bytes([0x77, 0x00, 0x02, 0x01, 0x02]))
         exception_thrown = False
@@ -63,6 +64,7 @@ def test_parser_extensions():
         exception_thrown = True
 
     assert not exception_thrown
+    assert len(sink.packets) == 0
 
     # Now add a custom info
     parser.extended_packet_info[0x77] = (1, 1, 'B')


### PR DESCRIPTION
## Overview
This PR addresses an issue where the some RTK BLE dongles fail to perform an HCI reset after the transport is torn down and re-instantiated. To address that, we prevent crashing the background threads when invalid data comes in, and handle resetting the parser. A retry for the HCI reset has been implemented for the RTK dongles where errant data comes in after being torn down. This is related to #476.

## Setup
1. Dongle: [Edimax BT-8500 Nano BT Adapter](https://www.amazon.com/dp/B08M1VJHVD)
2. OS: `Ubuntu 20.04.6 LTS`
3. Firmware: [`BT-8500 Linux Bluetooth Driver 1.0.0.3`](https://www.edimax.com/edimax/download/download/data/edimax/global/download/bluetooth/bt-8500) (Also tried the [Linux Kernel FW](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/rtl_bt/))

## Problem Description
### Issue 1
I observed that when closing and re-opening a transport to the Edimax BT Dongle (which has a RealTek chipset), that an HCI Reset would sometimes result in a second HCI reset response on the next command, requiring two HCI resets to be performed in the driver specific code.

### Issue 2
I observed that when the first HCI reset was performed after closing and re-opening a transport to the Edimax BT Dongle that sometimes the call would time out. Digging into the packet data, I observed that the data was sometimes invalid (examples follow):

```
b'\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0e\x04\x03\x03\x0c\x00'
```

```
b'\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
```

These would cause the background threads to crash, either from parsing the packet data, failing to handle the packet in `on_hci_packet()`, or failing to feed the data due to an invalid packet type.

## Proposed Changes
1. When performing an HCI reset in RTK's `driver_info_for_host`, perform the reset twice.
2. Expose the `hci_source` from the `Host`, and if the HCI reset fails in RTK's `driver_info_for_host`, clear the parser; this addresses the issue where we get errant packet data that causes the reset we get from the second command to fail to parse.
3. Add optional `timeout` to `send_command()` to allow for timing out the command.
4. In `host.on_packet()` capture when `hci.HCI_Packet.from_bytes()` fails.
5. Changed `raise ValueError` to `reset` and `break` in `ParserSource.feed_data()` to prevent crashing background thread when invalid packet type is found; allows the parser to continue parsing with the next bit of (hopefully good) data.