### PR TITLE
a2dp: emit delay_report

### DIFF
--- a/bumble/avdtp.py
+++ b/bumble/avdtp.py
@@ -2162,7 +2162,7 @@ class LocalStreamEndPoint(StreamEndPoint, EventEmitter):
     def on_abort_command(self):
         self.emit('abort')
 
-    def on_delayreport_command(self, delay):
+    def on_delayreport_command(self, delay: int):
         self.emit('delay_report', delay)
 
     def on_rtp_channel_open(self):

--- a/bumble/avdtp.py
+++ b/bumble/avdtp.py
@@ -2162,6 +2162,9 @@ class LocalStreamEndPoint(StreamEndPoint, EventEmitter):
     def on_abort_command(self):
         self.emit('abort')
 
+    def on_delayreport_command(self, delay):
+        self.emit('delay_report', delay)
+
     def on_rtp_channel_open(self):
         self.emit('rtp_channel_open')
 


### PR DESCRIPTION
Delay report commands were not handled. This handles them by emitting an event with the delay value.