### PR TITLE
 DH Key compute check modification for OOB Pairing

### DIFF
--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -1739,11 +1739,21 @@ class Session:
             ra = self.passkey.to_bytes(16, byteorder='little')
             rb = ra
         elif self.pairing_method == PairingMethod.OOB:
-            if self.peer_oob_data:
-                ra = self.peer_oob_data.r
+            if self.is_initiator:
+                if self.peer_oob_data:
+                    rb = self.peer_oob_data.r
+                    ra = self.r
+                else:
+                    rb = bytes(16)
+                    ra = self.r
             else:
-                ra = bytes(16)
-            rb = self.r
+                if self.peer_oob_data:
+                    ra = self.peer_oob_data.r
+                    rb = self.r
+                else:
+                    ra = bytes(16)
+                    rb = self.r
+
         else:
             return
 

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -764,7 +764,7 @@ class Session:
         self.peer_io_capability = SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY
 
         # OOB
-        self.oob_data_flag = 1 if pairing.oob and pairing_config.oob.peer_data else 0
+        self.oob_data_flag = 1 if pairing_config.oob and pairing_config.oob.peer_data else 0
 
         # Set up addresses
         self_address = connection.self_resolvable_address or connection.self_address

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -764,7 +764,9 @@ class Session:
         self.peer_io_capability = SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY
 
         # OOB
-        self.oob_data_flag = 1 if pairing_config.oob and pairing_config.oob.peer_data else 0
+        self.oob_data_flag = (
+            1 if pairing_config.oob and pairing_config.oob.peer_data else 0
+        )
 
         # Set up addresses
         self_address = connection.self_resolvable_address or connection.self_address

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -791,7 +791,7 @@ class Session:
                     raise InvalidArgumentError(
                         "oob pairing config requires a context when sc is True"
                     )
-                self.local_oob_r = pairing_config.oob.our_context.r
+                self.r = pairing_config.oob.our_context.r
                 self.ecc_key = pairing_config.oob.our_context.ecc_key
                 if pairing_config.oob.legacy_context is not None:
                     self.tk = pairing_config.oob.legacy_context.tk
@@ -800,12 +800,12 @@ class Session:
                     raise InvalidArgumentError(
                         "oob pairing config requires a legacy context when sc is False"
                     )
-                self.local_oob_r = bytes(16)
+                self.r = bytes(16)
                 self.ecc_key = manager.ecc_key
                 self.tk = pairing_config.oob.legacy_context.tk
         else:
             self.peer_oob_data = None
-            self.local_oob_r = bytes(16)
+            self.r = bytes(16)
             self.ecc_key = manager.ecc_key
             self.tk = bytes(16)
 
@@ -1014,8 +1014,10 @@ class Session:
         self.send_command(response)
 
     def send_pairing_confirm_command(self) -> None:
-        self.r = crypto.r()
-        logger.debug(f'generated random: {self.r.hex()}')
+
+        if self.pairing_method != PairingMethod.OOB:
+            self.r = crypto.r()
+            logger.debug(f'generated random: {self.r.hex()}')
 
         if self.sc:
 
@@ -1457,7 +1459,7 @@ class Session:
                 return
             if command.oob_data_flag == 0:
                 # The peer doesn't have OOB data, use r=0
-                self.local_oob_r = bytes(16)
+                self.r = bytes(16)
         else:
             # Decide which pairing method to use from the IO capability
             self.decide_pairing_method(
@@ -1527,7 +1529,7 @@ class Session:
                 return
             if command.oob_data_flag == 0:
                 # The peer doesn't have OOB data, use r=0
-                self.local_oob_r = bytes(16)
+                self.r = bytes(16)
         else:
             # Decide which pairing method to use from the IO capability
             self.decide_pairing_method(
@@ -1739,7 +1741,7 @@ class Session:
                 ra = self.peer_oob_data.r
             else:
                 ra = bytes(16)
-            rb = self.local_oob_r
+            rb = self.r
         else:
             return
 

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -764,11 +764,7 @@ class Session:
         self.peer_io_capability = SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY
 
         # OOB
-        self.oob_data_flag = 0
-        if pairing_config.oob is not None:
-            if pairing_config.oob.peer_data is not None:
-                self.oob_data_flag = 1
-
+        self.oob_data_flag = 1 if pairing.oob and pairing_config.oob.peer_data else 0
 
         # Set up addresses
         self_address = connection.self_resolvable_address or connection.self_address

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -764,7 +764,11 @@ class Session:
         self.peer_io_capability = SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY
 
         # OOB
-        self.oob_data_flag = 0 if pairing_config.oob.peer_data is None else 1
+        self.oob_data_flag = 0
+        if pairing_config.oob is not None:
+            if pairing_config.oob.peer_data is not None:
+                self.oob_data_flag = 1
+
 
         # Set up addresses
         self_address = connection.self_resolvable_address or connection.self_address


### PR DESCRIPTION
Code change
- for DH Key compute , ra and rb values are based on shared OOB randomizer value
- oob_data_flag should be 1 if remote device oob data present
![image](https://github.com/user-attachments/assets/d9ff82ec-79e5-4746-a967-04f019a64087)
- initial shared OOB randomizer value should not modified
 Please review the changes 