### PR TITLE
[Bug] Edimax BLE Dongle Fails After Teardown and Re-Instantiation

### DIFF
--- a/bumble/drivers/rtk.py
+++ b/bumble/drivers/rtk.py
@@ -301,6 +301,8 @@ class Driver(common.Driver):
         fw_name: str = ""
         config_name: str = ""
 
+    POST_RESET_DELAY: float = 0.2
+
     DRIVER_INFOS = [
         # 8723A
         DriverInfo(
@@ -495,12 +497,22 @@ class Driver(common.Driver):
 
     @classmethod
     async def driver_info_for_host(cls, host):
-        await host.send_command(HCI_Reset_Command(), check_result=True)
-        host.ready = True  # Needed to let the host know the controller is ready.
+        try:
+            await host.send_command(
+                HCI_Reset_Command(), check_result=True, response_timeout=cls.POST_RESET_DELAY
+            )
+            host.ready = True  # Needed to let the host know the controller is ready.
+        except asyncio.exceptions.TimeoutError:
+            logger.warning("timeout waiting for hci reset, retrying")
+            await host.send_command(HCI_Reset_Command(), check_result=True)
+            host.ready = True
 
-        response = await host.send_command(
-            HCI_Read_Local_Version_Information_Command(), check_result=True
-        )
+        command = HCI_Read_Local_Version_Information_Command()
+        response = await host.send_command(command, check_result=True)
+        if response.command_opcode != command.op_code:
+            logger.error("failed to probe local version information")
+            return None
+
         local_version = response.return_parameters
 
         logger.debug(

--- a/bumble/drivers/rtk.py
+++ b/bumble/drivers/rtk.py
@@ -499,7 +499,9 @@ class Driver(common.Driver):
     async def driver_info_for_host(cls, host):
         try:
             await host.send_command(
-                HCI_Reset_Command(), check_result=True, response_timeout=cls.POST_RESET_DELAY
+                HCI_Reset_Command(),
+                check_result=True,
+                response_timeout=cls.POST_RESET_DELAY,
             )
             host.ready = True  # Needed to let the host know the controller is ready.
         except asyncio.exceptions.TimeoutError:

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -514,7 +514,9 @@ class Host(AbortableEventEmitter):
         if self.hci_sink:
             self.hci_sink.on_packet(bytes(packet))
 
-    async def send_command(self, command, check_result=False, response_timeout: Optional[int] = None):
+    async def send_command(
+        self, command, check_result=False, response_timeout: Optional[int] = None
+    ):
         # Wait until we can send (only one pending command at a time)
         async with self.command_semaphore:
             assert self.pending_command is None

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -171,7 +171,7 @@ class Host(AbortableEventEmitter):
         self.cis_links = {}  # CIS links, by connection handle
         self.sco_links = {}  # SCO links, by connection handle
         self.pending_command = None
-        self.pending_response = None
+        self.pending_response: Optional[asyncio.Future[Any]] = None
         self.number_of_supported_advertising_sets = 0
         self.maximum_advertising_data_length = 31
         self.local_version = None
@@ -534,7 +534,7 @@ class Host(AbortableEventEmitter):
                 # Check the return parameters if required
                 if check_result:
                     if isinstance(response, hci.HCI_Command_Status_Event):
-                        status = response.status
+                        status = response.status  # type: ignore[attr-defined]
                     elif isinstance(response.return_parameters, int):
                         status = response.return_parameters
                     elif isinstance(response.return_parameters, bytes):


### PR DESCRIPTION
## Bug: Edimax BLE Dongle Fails After Teardown and Re-Instantiation
### Overview

Replacement for #497 with the logic for the HCI parser removed now that packets are handled without a parser for USB. This bug was observed with some RTK BLE dongles (specifically cheaper CSR dongles as well as the Edimax BT-8500). Sometimes, when a reset is attempted, the host will fail to receive a result, instead receiving an invalid packet or corrupt data. This results in blocking forever in `driver_info_for_host()`. In testing, I found that allowing that to time out, then trying again can work with dongles like the Edimax.

With cheaper CSR dongles, sometimes the first packet in response to a command after the reset will be an invalid packet. This occurs when the Local Version request is sent. The result is similar to the above in which case we wait forever on a packet that isn't coming in. In testing, I found that re-sending the command can sometimes avoid this, but not in all cases, so in the case that we do not get the local version information, we should skip over it and return upstream.

### Summary of Changes
1. In RTK `driver_info_for_host` attempt a HCI reset with a timeout; on time out, retry the HCI reset and assume the host is ready.
2. In RTK `driver_info_for_host` exit if the Local Version Information response is invalid.
3. In `bumble/host.py`, for `send_command()` allow an optional `response_timeout` to allow the caller to time out if a response is not received.
4. In `bumble/host.py`, for `on_packet()`, do not crash if `from_bytes()` fails to parse an HCI packet as may be the case with invalid data.