### PR TITLE
hotfix for usb transport

### DIFF
--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -139,7 +139,7 @@ async def open_usb_transport(spec: str) -> Transport:
             self.packets.put_nowait(packet)
 
         def transfer_callback(self, transfer):
-            self.acl_out_transfer_ready.release()
+            self.loop.call_soon_threadsafe(self.acl_out_transfer_ready.release)
             status = transfer.getStatus()
 
             # pylint: disable=no-member


### PR DESCRIPTION
the USB callback runs in the context of the USB loop thread, not the asyncio executor, so the call to release() must be deferred to an async context.