### PR TITLE
HAP: wait for pairing event

### DIFF
--- a/bumble/profiles/hap.py
+++ b/bumble/profiles/hap.py
@@ -26,7 +26,7 @@ from bumble.utils import AsyncRunner, OpenIntEnum
 from bumble.hci import Address
 from dataclasses import dataclass, field
 import logging
-from typing import Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 
 # -----------------------------------------------------------------------------
@@ -272,24 +272,12 @@ class HearingAccessService(gatt.TemplateService):
             def on_disconnection(_reason) -> None:
                 self.currently_connected_clients.remove(connection)
 
-            # TODO Should we filter on device bonded && device is HAP ?
-            self.currently_connected_clients.add(connection)
-            if (
-                connection.peer_address
-                not in self.preset_changed_operations_history_per_device
-            ):
-                self.preset_changed_operations_history_per_device[
-                    connection.peer_address
-                ] = []
-                return
+            @connection.on('pairing')  # type: ignore
+            def on_pairing(*_: Any) -> None:
+                self.on_incoming_paired_connection(connection)
 
-            async def on_connection_async() -> None:
-                # Send all the PresetChangedOperation that occur when not connected
-                await self._preset_changed_operation(connection)
-                # Update the active preset index if needed
-                await self.notify_active_preset_for_connection(connection)
-
-            connection.abort_on('disconnection', on_connection_async())
+            if connection.peer_resolvable_address:
+                self.on_incoming_paired_connection(connection)
 
         self.hearing_aid_features_characteristic = gatt.Characteristic(
             uuid=gatt.GATT_HEARING_AID_FEATURES_CHARACTERISTIC,
@@ -325,6 +313,27 @@ class HearingAccessService(gatt.TemplateService):
                 self.active_preset_index_characteristic,
             ]
         )
+
+    def on_incoming_paired_connection(self, connection: Connection):
+        '''Setup initial operations to handle a remote bonded HAP device'''
+        # TODO Should we filter on HAP device only ?
+        self.currently_connected_clients.add(connection)
+        if (
+            connection.peer_address
+            not in self.preset_changed_operations_history_per_device
+        ):
+            self.preset_changed_operations_history_per_device[
+                connection.peer_address
+            ] = []
+            return
+
+        async def on_connection_async() -> None:
+            # Send all the PresetChangedOperation that occur when not connected
+            await self._preset_changed_operation(connection)
+            # Update the active preset index if needed
+            await self.notify_active_preset_for_connection(connection)
+
+        connection.abort_on('disconnection', on_connection_async())
 
     def _on_read_active_preset_index(
         self, __connection__: Optional[Connection]

--- a/tests/hap_test.py
+++ b/tests/hap_test.py
@@ -25,6 +25,7 @@ import sys
 from bumble import att, device
 from bumble.profiles import hap
 from .test_utils import TwoDevices
+from bumble.keys import PairingKeys
 
 # -----------------------------------------------------------------------------
 # Logging
@@ -85,6 +86,10 @@ async def hap_client():
     # Mock encryption.
     devices.connections[0].encryption = 1  # type: ignore
     devices.connections[1].encryption = 1  # type: ignore
+
+    devices[0].on_pairing(
+        devices.connections[0], devices.connections[0].peer_address, PairingKeys(), True
+    )
 
     peer = device.Peer(devices.connections[1])  # type: ignore
     hap_client = await peer.discover_service_and_create_proxy(


### PR DESCRIPTION
HAP is supposed to work only when device are bonded.

By listening to the `on_pairing` event of the connection, we can start add the remote device to the `preset_changed_operations_history_per_device` only after the bonding (and thus the public address) has been done.

This missing logic was found thanks to https://r.android.com/3236429, an avatar test that try to delete a preset and then wait for the notification / indication to be sent to the device