### PR TITLE
run_csis_servers: Update `usage` and add docs entry

### DIFF
--- a/docs/mkdocs/src/examples/index.md
+++ b/docs/mkdocs/src/examples/index.md
@@ -42,6 +42,9 @@ An app that connected to a device (BLE) and encrypts the connection.
 ## `run_controller.py`
 Creates two linked controllers, attaches one to a transport, and the other to a local host with a GATT server application. This can be used, for example, to attach a virtual controller to a native stack, like BlueZ on Linux, and use the native tools, like `bluetoothctl`, to scan and connect to the GATT server included in the example.
 
+## `run_csis_servers.py`
+Runs CSIS servers on two devices to form a Coordinated Set. **Note**: If using the example config file (e.g. `device1.json`), the `address` needs to be removed, so that the devices are given different random addresses.   
+
 ## `run_gatt_client_and_server.py`
 Runs a local GATT server and GATT client, connected to each other. The GATT client discovers and logs all the services and characteristics exposed by the GATT server
 

--- a/docs/mkdocs/src/examples/index.md
+++ b/docs/mkdocs/src/examples/index.md
@@ -1,7 +1,7 @@
 EXAMPLES
 ========
 
-The project includes a few simple example applications the illustrate some of the ways the library APIs can be used.
+The project includes a few simple example applications to illustrate some of the ways the library APIs can be used.
 These examples include:
 
 ## `battery_service.py`

--- a/examples/run_csis_servers.py
+++ b/examples/run_csis_servers.py
@@ -38,13 +38,10 @@ from bumble.transport import open_transport_or_link
 async def main() -> None:
     if len(sys.argv) < 3:
         print(
-            'Usage: run_cig_setup.py <config-file>'
+            'Usage: run_csis_servers.py <config-file> '
             '<transport-spec-for-device-1> <transport-spec-for-device-2>'
         )
-        print(
-            'example: run_cig_setup.py device1.json'
-            'tcp-client:127.0.0.1:6402 tcp-client:127.0.0.1:6402'
-        )
+        print('example: run_csis_servers.py device1.json ' 'hci-socket:0 hci-socket:1')
         return
 
     print('<<< connecting to HCI...')


### PR DESCRIPTION
Amends the usage of the script and the example that show when executed incorrectly. 
Adds basic information to the `examples` section of the documentation.