### PR TITLE
HFP: Fix reading multiple AT commands from a single data packet

### DIFF
--- a/tests/hfp_test.py
+++ b/tests/hfp_test.py
@@ -576,7 +576,6 @@ async def test_hf_batched_response(
 ):
     hf, ag = hfp_connections
 
-    ag.send_response = lambda str: None
     ag.dlc.write(b'\r\n+BIND: (1,2)\r\n\r\nOK\r\n')
 
     await hf.execute_command("AT+BIND=?", response_type=hfp.AtResponseType.SINGLE)

--- a/tests/hfp_test.py
+++ b/tests/hfp_test.py
@@ -570,6 +570,38 @@ async def test_sco_setup():
 
 
 # -----------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_hf_batched_response(
+    hfp_connections: Tuple[hfp.HfProtocol, hfp.AgProtocol]
+):
+    hf, ag = hfp_connections
+
+    ag.send_response = lambda str: None
+    ag.dlc.write(b'\r\n+BIND: (1,2)\r\n\r\nOK\r\n')
+
+    await hf.execute_command("AT+BIND=?", response_type=hfp.AtResponseType.SINGLE)
+
+
+# -----------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_ag_batched_commands(
+    hfp_connections: Tuple[hfp.HfProtocol, hfp.AgProtocol]
+):
+    hf, ag = hfp_connections
+
+    answer_future = asyncio.get_running_loop().create_future()
+    ag.on('answer', lambda: answer_future.set_result(None))
+
+    hang_up_future = asyncio.get_running_loop().create_future()
+    ag.on('hang_up', lambda: hang_up_future.set_result(None))
+
+    hf.dlc.write(b'ATA\rAT+CHUP\r')
+
+    await answer_future
+    await hang_up_future
+
+
+# -----------------------------------------------------------------------------
 async def run():
     await test_slc()
 


### PR DESCRIPTION
The `data` received in `_read_at` may have multiple commands.

This fixes `execute_command` timing out when waiting for an `OK` response when it is in the same data buffer, e.g. during SLC initialization: b'\r\n+BRSF: 3904\r\n\r\nOK\r\n'