### PR TITLE
Add missing parameter 'flags' to ATT_Execute_Write_Request PDU

### DIFF
--- a/bumble/att.py
+++ b/bumble/att.py
@@ -710,7 +710,7 @@ class ATT_Prepare_Write_Response(ATT_PDU):
 
 
 # -----------------------------------------------------------------------------
-@ATT_PDU.subclass([])
+@ATT_PDU.subclass([("flags", 1)])
 class ATT_Execute_Write_Request(ATT_PDU):
     '''
     See Bluetooth spec @ Vol 3, Part F - 3.4.6.3 Execute Write Request


### PR DESCRIPTION
Bluetooth spec @ Vol 3, Part F - 3.4.6.3 Table 3.36 shows, that the ATT_EXECUTE_WRITE_REQ PDU contains the parameter 'Flags' with size 1 octet, which allows to cancel all prepared writes (0x00) or to immediately write all pending prepared values (0x01).