### PR TITLE
Remove characteristic in GATT Client unsubscribe() if it's the last subscriber

### DIFF
--- a/bumble/gatt_client.py
+++ b/bumble/gatt_client.py
@@ -898,6 +898,12 @@ class Client:
                 ) and subscriber in subscribers:
                     subscribers.remove(subscriber)
 
+                    # The characteristic itself is added as subscriber. If it is the
+                    # last remaining subscriber, we remove it, such that the clean up
+                    # works correctly. Otherwise the CCCD never is set back to 0.
+                    if len(subscribers) == 1 and characteristic in subscribers:
+                        subscribers.remove(characteristic)
+
                     # Cleanup if we removed the last one
                     if not subscribers:
                         del subscriber_set[characteristic.handle]


### PR DESCRIPTION
GATT Client's subscribe() adds the characteristic itself as subscriber. Therefore the characteristic has to be removed in unsubscribe(), if it's the last subscriber. Otherwise the clean up does not work correctly and the CCCD never is set back to 0 in the remote device.