### PR TITLE
fix #580

### DIFF
--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -1839,7 +1839,7 @@ class Session:
         if self.is_initiator:
             if self.pairing_method == PairingMethod.OOB:
                 self.send_pairing_random_command()
-            else:
+            elif self.pairing_method == PairingMethod.PASSKEY:
                 self.send_pairing_confirm_command()
         else:
             if self.pairing_method == PairingMethod.PASSKEY:

--- a/bumble/transport/common.py
+++ b/bumble/transport/common.py
@@ -370,11 +370,13 @@ class PumpedPacketSource(ParserSource):
                     self.parser.feed_data(packet)
                 except asyncio.CancelledError:
                     logger.debug('source pump task done')
-                    self.terminated.set_result(None)
+                    if not self.terminated.done():
+                        self.terminated.set_result(None)
                     break
                 except Exception as error:
                     logger.warning(f'exception while waiting for packet: {error}')
-                    self.terminated.set_exception(error)
+                    if not self.terminated.done():
+                        self.terminated.set_exception(error)
                     break
 
         self.pump_task = asyncio.create_task(pump_packets())


### PR DESCRIPTION
`PAIRING_CONFIRM` was sent by the initiator even in non-passkey methods, which isn't correct (somehow, this went unnoticed, because it seems both iOS and Android simply ignore this "extra" message).
With this fix, the initiator now only sends this message when in passkey mode. 