### PR TITLE
Correctly parse scan response from device config

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1660,6 +1660,10 @@ class DeviceConfiguration:
                 )
             )
 
+        # Load scan response data
+        if scan_response_data := config.pop('scan_response_data', None):
+            self.scan_response_data = bytes.fromhex(scan_response_data)
+
         # Load advertising interval (for backward compatibility)
         if advertising_interval := config.pop('advertising_interval', None):
             self.advertising_interval_min = advertising_interval


### PR DESCRIPTION
Parses scan response data correctly just like advertising data does with hex string. 