### PR TITLE
Improve Broadcast Scanning

### DIFF
--- a/bumble/core.py
+++ b/bumble/core.py
@@ -1624,6 +1624,9 @@ class AdvertisingData:
             [bytes([len(x[1]) + 1, x[0]]) + x[1] for x in self.ad_structures]
         )
 
+    def to_bytes(self) -> bytes:
+        return bytes(self)
+
     def to_string(self, separator=', '):
         return separator.join(
             [AdvertisingData.ad_data_to_string(x[0], x[1]) for x in self.ad_structures]

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -1482,7 +1482,7 @@ class CodingFormat:
     vendor_specific_codec_id: int = 0
 
     @classmethod
-    def parse_from_bytes(cls, data: bytes, offset: int):
+    def parse_from_bytes(cls, data: bytes, offset: int) -> tuple[int, CodingFormat]:
         (codec_id, company_id, vendor_specific_codec_id) = struct.unpack_from(
             '<BHH', data, offset
         )
@@ -1491,6 +1491,10 @@ class CodingFormat:
             company_id=company_id,
             vendor_specific_codec_id=vendor_specific_codec_id,
         )
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> CodingFormat:
+        return cls.parse_from_bytes(data, 0)[1]
 
     def to_bytes(self) -> bytes:
         return struct.pack(

--- a/examples/run_unicast_server.py
+++ b/examples/run_unicast_server.py
@@ -161,7 +161,13 @@ async def main() -> None:
             else:
                 file_output = open(f'{datetime.datetime.now().isoformat()}.lc3', 'wb')
                 codec_configuration = ase.codec_specific_configuration
-                assert isinstance(codec_configuration, CodecSpecificConfiguration)
+                if (
+                    not isinstance(codec_configuration, CodecSpecificConfiguration)
+                    or codec_configuration.sampling_frequency is None
+                    or codec_configuration.audio_channel_allocation is None
+                    or codec_configuration.frame_duration is None
+                ):
+                    return
                 # Write a LC3 header.
                 file_output.write(
                     bytes([0x1C, 0xCC])  # Header.

--- a/tests/bap_test.py
+++ b/tests/bap_test.py
@@ -39,6 +39,8 @@ from bumble.profiles.ascs import (
 )
 from bumble.profiles.bap import (
     AudioLocation,
+    BasicAudioAnnouncement,
+    BroadcastAudioAnnouncement,
     SupportedFrameDuration,
     SupportedSamplingFrequency,
     SamplingFrequency,
@@ -198,6 +200,56 @@ def test_codec_specific_configuration() -> None:
         codec_frames_per_sdu=1,
     )
     assert CodecSpecificConfiguration.from_bytes(bytes(config)) == config
+
+
+# -----------------------------------------------------------------------------
+def test_broadcast_audio_announcement() -> None:
+    broadcast_audio_announcement = BroadcastAudioAnnouncement(123456)
+    assert (
+        BroadcastAudioAnnouncement.from_bytes(bytes(broadcast_audio_announcement))
+        == broadcast_audio_announcement
+    )
+
+
+# -----------------------------------------------------------------------------
+def test_basic_audio_announcement() -> None:
+    basic_audio_announcement = BasicAudioAnnouncement(
+        presentation_delay=40000,
+        subgroups=[
+            BasicAudioAnnouncement.Subgroup(
+                codec_id=CodingFormat(codec_id=CodecID.LC3),
+                codec_specific_configuration=CodecSpecificConfiguration(
+                    sampling_frequency=SamplingFrequency.FREQ_48000,
+                    frame_duration=FrameDuration.DURATION_10000_US,
+                    octets_per_codec_frame=100,
+                ),
+                metadata=Metadata(
+                    [
+                        Metadata.Entry(tag=Metadata.Tag.LANGUAGE, data=b'eng'),
+                        Metadata.Entry(tag=Metadata.Tag.PROGRAM_INFO, data=b'Disco'),
+                    ]
+                ),
+                bis=[
+                    BasicAudioAnnouncement.BIS(
+                        index=0,
+                        codec_specific_configuration=CodecSpecificConfiguration(
+                            audio_channel_allocation=AudioLocation.FRONT_LEFT
+                        ),
+                    ),
+                    BasicAudioAnnouncement.BIS(
+                        index=1,
+                        codec_specific_configuration=CodecSpecificConfiguration(
+                            audio_channel_allocation=AudioLocation.FRONT_RIGHT
+                        ),
+                    ),
+                ],
+            )
+        ],
+    )
+    assert (
+        BasicAudioAnnouncement.from_bytes(bytes(basic_audio_announcement))
+        == basic_audio_announcement
+    )
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
* APP: Allow scanning for broadcast without name (check annoucement instead)
* Add BAP dataclass serializer
* Allow nullable codec specific configuration fields
* Remove BAP CodecID (use HCI CodecID/Format instead, though the term is a little bit confusing)