### PR TITLE
Amend Opcode value in `Audio Input Control Service`

### DIFF
--- a/bumble/profiles/aics.py
+++ b/bumble/profiles/aics.py
@@ -104,7 +104,7 @@ class AudioInputControlPointOpCode(OpenIntEnum):
     Cf. 3.5.1 Audio Input Control Point procedure requirements
     '''
 
-    SET_GAIN_SETTING = 0x00
+    SET_GAIN_SETTING = 0x01
     UNMUTE = 0x02
     MUTE = 0x03
     SET_MANUAL_GAIN_MODE = 0x04

--- a/bumble/profiles/aics.py
+++ b/bumble/profiles/aics.py
@@ -95,7 +95,7 @@ class AudioInputStatus(OpenIntEnum):
     Cf. 3.4 Audio Input Status
     '''
 
-    INATIVE = 0x00
+    INACTIVE = 0x00
     ACTIVE = 0x01
 
 
@@ -239,7 +239,7 @@ class AudioInputControlPoint:
             or gain_settings_operand
             > self.gain_settings_properties.gain_settings_maximum
         ):
-            logger.error("gain_seetings value out of range")
+            logger.error("gain_settings value out of range")
             raise ATT_Error(ErrorCode.VALUE_OUT_OF_RANGE)
 
         if self.audio_input_state.gain_settings != gain_settings_operand:


### PR DESCRIPTION
Corrects the Audio Input Control Point Opcode value for `Set Gain Setting` field.

As per the specifications `Audio Input Control Service v1.0`, section `3.5.1 Audio Input Control Point procedure requirements` the value should be 0x01.
