### PR TITLE
Add a class-based GATT adapter

### DIFF
--- a/bumble/att.py
+++ b/bumble/att.py
@@ -759,13 +759,13 @@ class AttributeValue:
     def __init__(
         self,
         read: Union[
-            Callable[[Optional[Connection]], bytes],
-            Callable[[Optional[Connection]], Awaitable[bytes]],
+            Callable[[Optional[Connection]], Any],
+            Callable[[Optional[Connection]], Awaitable[Any]],
             None,
         ] = None,
         write: Union[
-            Callable[[Optional[Connection], bytes], None],
-            Callable[[Optional[Connection], bytes], Awaitable[None]],
+            Callable[[Optional[Connection], Any], None],
+            Callable[[Optional[Connection], Any], Awaitable[None]],
             None,
         ] = None,
     ):
@@ -824,13 +824,13 @@ class Attribute(EventEmitter):
     READ_REQUIRES_AUTHORIZATION = Permissions.READ_REQUIRES_AUTHORIZATION
     WRITE_REQUIRES_AUTHORIZATION = Permissions.WRITE_REQUIRES_AUTHORIZATION
 
-    value: Union[bytes, AttributeValue]
+    value: Any
 
     def __init__(
         self,
         attribute_type: Union[str, bytes, UUID],
         permissions: Union[str, Attribute.Permissions],
-        value: Union[str, bytes, AttributeValue] = b'',
+        value: Any = b'',
     ) -> None:
         EventEmitter.__init__(self)
         self.handle = 0
@@ -848,11 +848,7 @@ class Attribute(EventEmitter):
         else:
             self.type = attribute_type
 
-        # Convert the value to a byte array
-        if isinstance(value, str):
-            self.value = bytes(value, 'utf-8')
-        else:
-            self.value = value
+        self.value = value
 
     def encode_value(self, value: Any) -> bytes:
         return value
@@ -894,6 +890,8 @@ class Attribute(EventEmitter):
                 ) from error
         else:
             value = self.value
+
+        self.emit('read', connection, value)
 
         return self.encode_value(value)
 

--- a/bumble/gatt_server.py
+++ b/bumble/gatt_server.py
@@ -28,7 +28,17 @@ import asyncio
 import logging
 from collections import defaultdict
 import struct
-from typing import List, Tuple, Optional, TypeVar, Type, Dict, Iterable, TYPE_CHECKING
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Type,
+    Union,
+    TYPE_CHECKING,
+)
 from pyee import EventEmitter
 
 from bumble.colors import color
@@ -68,6 +78,7 @@ from bumble.gatt import (
     GATT_REQUEST_TIMEOUT,
     GATT_SECONDARY_SERVICE_ATTRIBUTE_TYPE,
     Characteristic,
+    CharacteristicAdapter,
     CharacteristicDeclaration,
     CharacteristicValue,
     IncludedServiceDeclaration,

--- a/bumble/profiles/bass.py
+++ b/bumble/profiles/bass.py
@@ -276,10 +276,7 @@ class BroadcastReceiveState:
     subgroups: List[SubgroupInfo]
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> Optional[BroadcastReceiveState]:
-        if not data:
-            return None
-
+    def from_bytes(cls, data: bytes) -> BroadcastReceiveState:
         source_id = data[0]
         _, source_address = hci.Address.parse_address_preceded_by_type(data, 2)
         source_adv_sid = data[8]
@@ -357,7 +354,7 @@ class BroadcastAudioScanServiceProxy(gatt_client.ProfileServiceProxy):
     SERVICE_CLASS = BroadcastAudioScanService
 
     broadcast_audio_scan_control_point: gatt_client.CharacteristicProxy
-    broadcast_receive_states: List[gatt.DelegatedCharacteristicAdapter]
+    broadcast_receive_states: List[gatt.SerializableCharacteristicAdapter]
 
     def __init__(self, service_proxy: gatt_client.ServiceProxy):
         self.service_proxy = service_proxy
@@ -381,8 +378,8 @@ class BroadcastAudioScanServiceProxy(gatt_client.ProfileServiceProxy):
                 "Broadcast Receive State characteristic not found"
             )
         self.broadcast_receive_states = [
-            gatt.DelegatedCharacteristicAdapter(
-                characteristic, decode=BroadcastReceiveState.from_bytes
+            gatt.SerializableCharacteristicAdapter(
+                characteristic, BroadcastReceiveState
             )
             for characteristic in characteristics
         ]

--- a/bumble/profiles/device_information_service.py
+++ b/bumble/profiles/device_information_service.py
@@ -64,7 +64,10 @@ class DeviceInformationService(TemplateService):
     ):
         characteristics = [
             Characteristic(
-                uuid, Characteristic.Properties.READ, Characteristic.READABLE, field
+                uuid,
+                Characteristic.Properties.READ,
+                Characteristic.READABLE,
+                bytes(field, 'utf-8'),
             )
             for (field, uuid) in (
                 (manufacturer_name, GATT_MANUFACTURER_NAME_STRING_CHARACTERISTIC),

--- a/bumble/profiles/heart_rate_service.py
+++ b/bumble/profiles/heart_rate_service.py
@@ -30,6 +30,7 @@ from ..gatt import (
     TemplateService,
     Characteristic,
     CharacteristicValue,
+    SerializableCharacteristicAdapter,
     DelegatedCharacteristicAdapter,
     PackedCharacteristicAdapter,
 )
@@ -150,15 +151,14 @@ class HeartRateService(TemplateService):
         body_sensor_location=None,
         reset_energy_expended=None,
     ):
-        self.heart_rate_measurement_characteristic = DelegatedCharacteristicAdapter(
+        self.heart_rate_measurement_characteristic = SerializableCharacteristicAdapter(
             Characteristic(
                 GATT_HEART_RATE_MEASUREMENT_CHARACTERISTIC,
                 Characteristic.Properties.NOTIFY,
                 0,
                 CharacteristicValue(read=read_heart_rate_measurement),
             ),
-            # pylint: disable=unnecessary-lambda
-            encode=lambda value: bytes(value),
+            HeartRateService.HeartRateMeasurement,
         )
         characteristics = [self.heart_rate_measurement_characteristic]
 
@@ -204,9 +204,8 @@ class HeartRateServiceProxy(ProfileServiceProxy):
         if characteristics := service_proxy.get_characteristics_by_uuid(
             GATT_HEART_RATE_MEASUREMENT_CHARACTERISTIC
         ):
-            self.heart_rate_measurement = DelegatedCharacteristicAdapter(
-                characteristics[0],
-                decode=HeartRateService.HeartRateMeasurement.from_bytes,
+            self.heart_rate_measurement = SerializableCharacteristicAdapter(
+                characteristics[0], HeartRateService.HeartRateMeasurement
             )
         else:
             self.heart_rate_measurement = None

--- a/bumble/utils.py
+++ b/bumble/utils.py
@@ -24,17 +24,19 @@ import logging
 import sys
 import warnings
 from typing import (
-    Awaitable,
-    Set,
-    TypeVar,
-    List,
-    Tuple,
-    Callable,
     Any,
+    Awaitable,
+    Callable,
+    List,
     Optional,
+    Protocol,
+    Set,
+    Tuple,
+    TypeVar,
     Union,
     overload,
 )
+from typing_extensions import Self
 
 from pyee import EventEmitter
 
@@ -487,3 +489,16 @@ class OpenIntEnum(enum.IntEnum):
         obj._value_ = value
         obj._name_ = f"{cls.__name__}[{value}]"
         return obj
+
+
+# -----------------------------------------------------------------------------
+class ByteSerializable(Protocol):
+    """
+    Type protocol for classes that can be instantiated from bytes and serialized
+    to bytes.
+    """
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Self: ...
+
+    def __bytes__(self) -> bytes: ...

--- a/examples/keyboard.py
+++ b/examples/keyboard.py
@@ -282,7 +282,7 @@ async def keyboard_device(device, command):
                         GATT_MANUFACTURER_NAME_STRING_CHARACTERISTIC,
                         Characteristic.Properties.READ,
                         Characteristic.READABLE,
-                        'Bumble',
+                        bytes('Bumble', 'utf-8'),
                     )
                 ],
             ),

--- a/examples/run_gatt_server.py
+++ b/examples/run_gatt_server.py
@@ -127,7 +127,7 @@ async def main() -> None:
                     '486F64C6-4B5F-4B3B-8AFF-EDE134A8446A',
                     Characteristic.Properties.READ | Characteristic.Properties.NOTIFY,
                     Characteristic.READABLE,
-                    'hello',
+                    bytes('hello', 'utf-8'),
                 ),
             ],
         )

--- a/examples/run_gatt_with_adapters.py
+++ b/examples/run_gatt_with_adapters.py
@@ -1,0 +1,319 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Imports
+# -----------------------------------------------------------------------------
+from __future__ import annotations
+import asyncio
+import dataclasses
+import logging
+import os
+import random
+import struct
+import sys
+from typing import Any, List, Union
+
+from bumble.device import Connection, Device, Peer
+from bumble import transport
+from bumble import gatt
+from bumble import hci
+from bumble import core
+
+
+# -----------------------------------------------------------------------------
+SERVICE_UUID = core.UUID("50DB505C-8AC4-4738-8448-3B1D9CC09CC5")
+CHARACTERISTIC_UUID_BASE = "D901B45B-4916-412E-ACCA-0000000000"
+
+
+# -----------------------------------------------------------------------------
+@dataclasses.dataclass
+class CustomSerializableClass:
+    x: int
+    y: int
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> CustomSerializableClass:
+        return cls(*struct.unpack(">II", data))
+
+    def __bytes__(self) -> bytes:
+        return struct.pack(">II", self.x, self.y)
+
+
+# -----------------------------------------------------------------------------
+@dataclasses.dataclass
+class CustomClass:
+    a: int
+    b: int
+
+    @classmethod
+    def decode(cls, data: bytes) -> CustomClass:
+        return cls(*struct.unpack(">II", data))
+
+    def encode(self) -> bytes:
+        return struct.pack(">II", self.a, self.b)
+
+
+# -----------------------------------------------------------------------------
+async def client(device: Device, address: hci.Address) -> None:
+    print(f'=== Connecting to {address}...')
+    connection = await device.connect(address)
+    print('=== Connected')
+
+    # Discover all characteristics.
+    peer = Peer(connection)
+    print("*** Discovering services and characteristics...")
+    await peer.discover_all()
+    print("*** Discovery complete")
+
+    service = peer.get_services_by_uuid(SERVICE_UUID)[0]
+    characteristics = []
+    for index in range(1, 9):
+        characteristics.append(
+            service.get_characteristics_by_uuid(
+                CHARACTERISTIC_UUID_BASE + f"{index:02X}"
+            )[0]
+        )
+
+    # Read all characteristics as raw bytes.
+    for characteristic in characteristics:
+        value = await characteristic.read_value()
+        print(f"### {characteristic} = {value} ({value.hex()})")
+
+    # Static characteristic with a bytes value.
+    c1 = characteristics[0]
+    c1_value = await c1.read_value()
+    print(f"@@@ C1 {c1} value = {c1_value} (type={type(c1_value)})")
+    await c1.write_value("happy π day".encode("utf-8"))
+
+    # Static characteristic with a string value.
+    c2 = gatt.UTF8CharacteristicAdapter(characteristics[1])
+    c2_value = await c2.read_value()
+    print(f"@@@ C2 {c2} value = {c2_value} (type={type(c2_value)})")
+    await c2.write_value("happy π day")
+
+    # Static characteristic with a tuple value.
+    c3 = gatt.PackedCharacteristicAdapter(characteristics[2], ">III")
+    c3_value = await c3.read_value()
+    print(f"@@@ C3 {c3} value = {c3_value} (type={type(c3_value)})")
+    await c3.write_value((2001, 2002, 2003))
+
+    # Static characteristic with a named tuple value.
+    c4 = gatt.MappedCharacteristicAdapter(
+        characteristics[3], ">III", ["f1", "f2", "f3"]
+    )
+    c4_value = await c4.read_value()
+    print(f"@@@ C4 {c4} value = {c4_value} (type={type(c4_value)})")
+    await c4.write_value({"f1": 4001, "f2": 4002, "f3": 4003})
+
+    # Static characteristic with a serializable value.
+    c5 = gatt.SerializableCharacteristicAdapter(
+        characteristics[4], CustomSerializableClass
+    )
+    c5_value = await c5.read_value()
+    print(f"@@@ C5 {c5} value = {c5_value} (type={type(c5_value)})")
+    await c5.write_value(CustomSerializableClass(56, 57))
+
+    # Static characteristic with a delegated value.
+    c6 = gatt.DelegatedCharacteristicAdapter(
+        characteristics[5], encode=CustomClass.encode, decode=CustomClass.decode
+    )
+    c6_value = await c6.read_value()
+    print(f"@@@ C6 {c6} value = {c6_value} (type={type(c6_value)})")
+    await c6.write_value(CustomClass(6, 7))
+
+    # Dynamic characteristic with a bytes value.
+    c7 = characteristics[6]
+    c7_value = await c7.read_value()
+    print(f"@@@ C7 {c7} value = {c7_value} (type={type(c7_value)})")
+    await c7.write_value(bytes.fromhex("01020304"))
+
+    # Dynamic characteristic with a string value.
+    c8 = gatt.UTF8CharacteristicAdapter(characteristics[7])
+    c8_value = await c8.read_value()
+    print(f"@@@ C8 {c8} value = {c8_value} (type={type(c8_value)})")
+    await c8.write_value("howdy")
+
+
+# -----------------------------------------------------------------------------
+def dynamic_read(selector: str) -> Union[bytes, str]:
+    if selector == "bytes":
+        print("$$$ Returning random bytes")
+        return random.randbytes(7)
+    elif selector == "string":
+        print("$$$ Returning random string")
+        return random.randbytes(7).hex()
+
+    raise ValueError("invalid selector")
+
+
+# -----------------------------------------------------------------------------
+def dynamic_write(selector: str, value: Any) -> None:
+    print(f"$$$ Received[{selector}]: {value} (type={type(value)})")
+
+
+# -----------------------------------------------------------------------------
+def on_characteristic_read(characteristic: gatt.Characteristic, value: Any) -> None:
+    """Event listener invoked when a characteristic is read."""
+    print(f"<<< READ: {characteristic} -> {value} ({type(value)})")
+
+
+# -----------------------------------------------------------------------------
+def on_characteristic_write(characteristic: gatt.Characteristic, value: Any) -> None:
+    """Event listener invoked when a characteristic is written."""
+    print(f"<<< WRITE: {characteristic} <- {value}  ({type(value)})")
+
+
+# -----------------------------------------------------------------------------
+async def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: run_gatt_with_adapters.py <transport-spec> [<bluetooth-address>]")
+        print("example: run_gatt_with_adapters.py usb:0 E1:CA:72:48:C4:E8")
+        return
+
+    async with await transport.open_transport(sys.argv[1]) as hci_transport:
+        # Create a device to manage the host
+        device = Device.with_hci(
+            "Bumble",
+            hci.Address("F0:F1:F2:F3:F4:F5"),
+            hci_transport.source,
+            hci_transport.sink,
+        )
+
+        # Static characteristic with a bytes value.
+        c1 = gatt.Characteristic(
+            CHARACTERISTIC_UUID_BASE + "01",
+            gatt.Characteristic.Properties.READ | gatt.Characteristic.Properties.WRITE,
+            gatt.Characteristic.READABLE | gatt.Characteristic.WRITEABLE,
+            b'hello',
+        )
+
+        # Static characteristic with a string value.
+        c2 = gatt.UTF8CharacteristicAdapter(
+            gatt.Characteristic(
+                CHARACTERISTIC_UUID_BASE + "02",
+                gatt.Characteristic.Properties.READ
+                | gatt.Characteristic.Properties.WRITE,
+                gatt.Characteristic.READABLE | gatt.Characteristic.WRITEABLE,
+                'hello',
+            )
+        )
+
+        # Static characteristic with a tuple value.
+        c3 = gatt.PackedCharacteristicAdapter(
+            gatt.Characteristic(
+                CHARACTERISTIC_UUID_BASE + "03",
+                gatt.Characteristic.Properties.READ
+                | gatt.Characteristic.Properties.WRITE,
+                gatt.Characteristic.READABLE | gatt.Characteristic.WRITEABLE,
+                (1007, 1008, 1009),
+            ),
+            ">III",
+        )
+
+        # Static characteristic with a named tuple value.
+        c4 = gatt.MappedCharacteristicAdapter(
+            gatt.Characteristic(
+                CHARACTERISTIC_UUID_BASE + "04",
+                gatt.Characteristic.Properties.READ
+                | gatt.Characteristic.Properties.WRITE,
+                gatt.Characteristic.READABLE | gatt.Characteristic.WRITEABLE,
+                {"f1": 3007, "f2": 3008, "f3": 3009},
+            ),
+            ">III",
+            ["f1", "f2", "f3"],
+        )
+
+        # Static characteristic with a serializable value.
+        c5 = gatt.SerializableCharacteristicAdapter(
+            gatt.Characteristic(
+                CHARACTERISTIC_UUID_BASE + "05",
+                gatt.Characteristic.Properties.READ
+                | gatt.Characteristic.Properties.WRITE,
+                gatt.Characteristic.READABLE | gatt.Characteristic.WRITEABLE,
+                CustomSerializableClass(11, 12),
+            ),
+            CustomSerializableClass,
+        )
+
+        # Static characteristic with a delegated value.
+        c6 = gatt.DelegatedCharacteristicAdapter(
+            gatt.Characteristic(
+                CHARACTERISTIC_UUID_BASE + "06",
+                gatt.Characteristic.Properties.READ
+                | gatt.Characteristic.Properties.WRITE,
+                gatt.Characteristic.READABLE | gatt.Characteristic.WRITEABLE,
+                CustomClass(1, 2),
+            ),
+            encode=CustomClass.encode,
+            decode=CustomClass.decode,
+        )
+
+        # Dynamic characteristic with a bytes value.
+        c7 = gatt.Characteristic(
+            CHARACTERISTIC_UUID_BASE + "07",
+            gatt.Characteristic.Properties.READ | gatt.Characteristic.Properties.WRITE,
+            gatt.Characteristic.READABLE | gatt.Characteristic.WRITEABLE,
+            gatt.CharacteristicValue(
+                read=lambda connection: dynamic_read("bytes"),
+                write=lambda connection, value: dynamic_write("bytes", value),
+            ),
+        )
+
+        # Dynamic characteristic with a string value.
+        c8 = gatt.UTF8CharacteristicAdapter(
+            gatt.Characteristic(
+                CHARACTERISTIC_UUID_BASE + "08",
+                gatt.Characteristic.Properties.READ
+                | gatt.Characteristic.Properties.WRITE,
+                gatt.Characteristic.READABLE | gatt.Characteristic.WRITEABLE,
+                gatt.CharacteristicValue(
+                    read=lambda connection: dynamic_read("string"),
+                    write=lambda connection, value: dynamic_write("string", value),
+                ),
+            )
+        )
+
+        characteristics: List[
+            Union[gatt.Characteristic, gatt.CharacteristicAdapter]
+        ] = [c1, c2, c3, c4, c5, c6, c7, c8]
+
+        # Listen for read and write events.
+        for characteristic in characteristics:
+            characteristic.on(
+                "read",
+                lambda _, value, c=characteristic: on_characteristic_read(c, value),
+            )
+            characteristic.on(
+                "write",
+                lambda _, value, c=characteristic: on_characteristic_write(c, value),
+            )
+
+        device.add_service(gatt.Service(SERVICE_UUID, characteristics))  # type: ignore
+
+        # Get things going
+        await device.power_on()
+
+        # Connect to a peer
+        if len(sys.argv) > 2:
+            await client(device, hci.Address(sys.argv[2]))
+        else:
+            await device.start_advertising(auto_restart=True)
+
+        await hci_transport.source.wait_for_termination()
+
+
+# -----------------------------------------------------------------------------
+logging.basicConfig(level=os.environ.get('BUMBLE_LOGLEVEL', 'INFO').upper())
+asyncio.run(main())

--- a/tests/aics_test.py
+++ b/tests/aics_test.py
@@ -28,6 +28,7 @@ from bumble.profiles.aics import (
     AudioInputState,
     AICSServiceProxy,
     GainMode,
+    GainSettingsProperties,
     AudioInputStatus,
     AudioInputControlPointOpCode,
     ErrorCode,
@@ -82,7 +83,12 @@ async def test_init_service(aics_client: AICSServiceProxy):
         gain_mode=GainMode.MANUAL,
         change_counter=0,
     )
-    assert await aics_client.gain_settings_properties.read_value() == (1, 0, 255)
+    assert (
+        await aics_client.gain_settings_properties.read_value()
+        == GainSettingsProperties(
+            gain_settings_unit=1, gain_settings_minimum=0, gain_settings_maximum=255
+        )
+    )
     assert await aics_client.audio_input_status.read_value() == (
         AudioInputStatus.ACTIVE
     )
@@ -481,12 +487,12 @@ async def test_set_automatic_gain_mode_when_automatic_only(
 @pytest.mark.asyncio
 async def test_audio_input_description_initial_value(aics_client: AICSServiceProxy):
     description = await aics_client.audio_input_description.read_value()
-    assert description.decode('utf-8') == "Bluetooth"
+    assert description == "Bluetooth"
 
 
 @pytest.mark.asyncio
 async def test_audio_input_description_write_and_read(aics_client: AICSServiceProxy):
-    new_description = "Line Input".encode('utf-8')
+    new_description = "Line Input"
 
     await aics_client.audio_input_description.write_value(new_description)
 


### PR DESCRIPTION
This new adapter makes it convenient to use classes that follow the `from_bytes` and `__bytes__` conventions. For any class that conforms to this protocol, the adapter will automatically convert GATT bytes values to/from class objects.

This PR also removes the support for directly constructing a `gatt.Characteristic` with an `str` value. Instead, callers must either perform the conversion themselves, or use the standard `UT8CharacteristicAdapter`. (allowing passing `str` at construction was a broken API, because it would perform the conversion to bytes only at construction time, but wouldn't perform the conversion subsequently if assigning a new value. So it is better to remove it altogether.
