### PR TITLE
only use `__bytes__` when not argument is needed.

### DIFF
--- a/apps/hci_bridge.py
+++ b/apps/hci_bridge.py
@@ -83,7 +83,7 @@ async def async_main():
                         return_parameters=bytes([hci.HCI_SUCCESS]),
                     )
                     # Return a packet with 'respond to sender' set to True
-                    return (response.to_bytes(), True)
+                    return (bytes(response), True)
 
                 return None
 

--- a/bumble/att.py
+++ b/bumble/att.py
@@ -291,9 +291,6 @@ class ATT_PDU:
     def init_from_bytes(self, pdu, offset):
         return HCI_Object.init_from_bytes(self, pdu, offset, self.fields)
 
-    def to_bytes(self):
-        return self.pdu
-
     @property
     def is_command(self):
         return ((self.op_code >> 6) & 1) == 1
@@ -303,7 +300,7 @@ class ATT_PDU:
         return ((self.op_code >> 7) & 1) == 1
 
     def __bytes__(self):
-        return self.to_bytes()
+        return self.pdu
 
     def __str__(self):
         result = color(self.name, 'yellow')

--- a/bumble/controller.py
+++ b/bumble/controller.py
@@ -314,7 +314,7 @@ class Controller:
             f'{color("CONTROLLER -> HOST", "green")}: {packet}'
         )
         if self.host:
-            self.host.on_packet(packet.to_bytes())
+            self.host.on_packet(bytes(packet))
 
     # This method allows the controller to emulate the same API as a transport source
     async def wait_for_termination(self):
@@ -1192,7 +1192,7 @@ class Controller:
         See Bluetooth spec Vol 4, Part E - 7.4.6 Read BD_ADDR Command
         '''
         bd_addr = (
-            self._public_address.to_bytes()
+            bytes(self._public_address)
             if self._public_address is not None
             else bytes(6)
         )

--- a/bumble/core.py
+++ b/bumble/core.py
@@ -1624,9 +1624,6 @@ class AdvertisingData:
             [bytes([len(x[1]) + 1, x[0]]) + x[1] for x in self.ad_structures]
         )
 
-    def to_bytes(self) -> bytes:
-        return bytes(self)
-
     def to_string(self, separator=', '):
         return separator.join(
             [AdvertisingData.ad_data_to_string(x[0], x[1]) for x in self.ad_structures]

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1986,7 +1986,7 @@ class Device(CompositeEventEmitter):
         check_address_type: bool = False,
     ) -> Optional[Connection]:
         for connection in self.connections.values():
-            if connection.peer_address.to_bytes() == bd_addr.to_bytes():
+            if bytes(connection.peer_address) == bytes(bd_addr):
                 if (
                     check_address_type
                     and connection.peer_address.address_type != bd_addr.address_type

--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -410,7 +410,7 @@ class IncludedServiceDeclaration(Attribute):
 
     def __init__(self, service: Service) -> None:
         declaration_bytes = struct.pack(
-            '<HH2s', service.handle, service.end_group_handle, service.uuid.to_bytes()
+            '<HH2s', service.handle, service.end_group_handle, bytes(service.uuid)
         )
         super().__init__(
             GATT_INCLUDE_ATTRIBUTE_TYPE, Attribute.READABLE, declaration_bytes

--- a/bumble/gatt_client.py
+++ b/bumble/gatt_client.py
@@ -292,7 +292,7 @@ class Client:
         logger.debug(
             f'GATT Command from client: [0x{self.connection.handle:04X}] {command}'
         )
-        self.send_gatt_pdu(command.to_bytes())
+        self.send_gatt_pdu(bytes(command))
 
     async def send_request(self, request: ATT_PDU):
         logger.debug(
@@ -310,7 +310,7 @@ class Client:
             self.pending_request = request
 
             try:
-                self.send_gatt_pdu(request.to_bytes())
+                self.send_gatt_pdu(bytes(request))
                 response = await asyncio.wait_for(
                     self.pending_response, GATT_REQUEST_TIMEOUT
                 )
@@ -328,7 +328,7 @@ class Client:
             f'GATT Confirmation from client: [0x{self.connection.handle:04X}] '
             f'{confirmation}'
         )
-        self.send_gatt_pdu(confirmation.to_bytes())
+        self.send_gatt_pdu(bytes(confirmation))
 
     async def request_mtu(self, mtu: int) -> int:
         # Check the range

--- a/bumble/gatt_server.py
+++ b/bumble/gatt_server.py
@@ -353,7 +353,7 @@ class Server(EventEmitter):
         logger.debug(
             f'GATT Response from server: [0x{connection.handle:04X}] {response}'
         )
-        self.send_gatt_pdu(connection.handle, response.to_bytes())
+        self.send_gatt_pdu(connection.handle, bytes(response))
 
     async def notify_subscriber(
         self,
@@ -450,7 +450,7 @@ class Server(EventEmitter):
             )
 
             try:
-                self.send_gatt_pdu(connection.handle, indication.to_bytes())
+                self.send_gatt_pdu(connection.handle, bytes(indication))
                 await asyncio.wait_for(pending_confirmation, GATT_REQUEST_TIMEOUT)
             except asyncio.TimeoutError as error:
                 logger.warning(color('!!! GATT Indicate timeout', 'red'))

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -199,7 +199,7 @@ class Host(AbortableEventEmitter):
         check_address_type: bool = False,
     ) -> Optional[Connection]:
         for connection in self.connections.values():
-            if connection.peer_address.to_bytes() == bd_addr.to_bytes():
+            if bytes(connection.peer_address) == bytes(bd_addr):
                 if (
                     check_address_type
                     and connection.peer_address.address_type != bd_addr.address_type

--- a/bumble/l2cap.py
+++ b/bumble/l2cap.py
@@ -225,16 +225,13 @@ class L2CAP_PDU:
 
         return L2CAP_PDU(l2cap_pdu_cid, l2cap_pdu_payload)
 
-    def to_bytes(self) -> bytes:
+    def __bytes__(self) -> bytes:
         header = struct.pack('<HH', len(self.payload), self.cid)
         return header + self.payload
 
     def __init__(self, cid: int, payload: bytes) -> None:
         self.cid = cid
         self.payload = payload
-
-    def __bytes__(self) -> bytes:
-        return self.to_bytes()
 
     def __str__(self) -> str:
         return f'{color("L2CAP", "green")} [CID={self.cid}]: {self.payload.hex()}'
@@ -333,11 +330,8 @@ class L2CAP_Control_Frame:
     def init_from_bytes(self, pdu, offset):
         return HCI_Object.init_from_bytes(self, pdu, offset, self.fields)
 
-    def to_bytes(self) -> bytes:
-        return self.pdu
-
     def __bytes__(self) -> bytes:
-        return self.to_bytes()
+        return self.pdu
 
     def __str__(self) -> str:
         result = f'{color(self.name, "yellow")} [ID={self.identifier}]'

--- a/bumble/profiles/bap.py
+++ b/bumble/profiles/bap.py
@@ -265,7 +265,7 @@ class UnicastServerAdvertisingData:
                         core.AdvertisingData.SERVICE_DATA_16_BIT_UUID,
                         struct.pack(
                             '<2sBIB',
-                            gatt.GATT_AUDIO_STREAM_CONTROL_SERVICE.to_bytes(),
+                            bytes(gatt.GATT_AUDIO_STREAM_CONTROL_SERVICE),
                             self.announcement_type,
                             self.available_audio_contexts,
                             len(self.metadata),
@@ -487,24 +487,23 @@ class BroadcastAudioAnnouncement:
     def from_bytes(cls, data: bytes) -> Self:
         return cls(int.from_bytes(data[:3], 'little'))
 
-    def to_bytes(self) -> bytes:
+    def __bytes__(self) -> bytes:
         return self.broadcast_id.to_bytes(3, 'little')
 
-    def __bytes__(self) -> bytes:
-        return self.to_bytes()
-
     def get_advertising_data(self) -> bytes:
-        return core.AdvertisingData(
-            [
-                (
-                    core.AdvertisingData.SERVICE_DATA_16_BIT_UUID,
+        return bytes(
+            core.AdvertisingData(
+                [
                     (
-                        gatt.GATT_BROADCAST_AUDIO_ANNOUNCEMENT_SERVICE.to_bytes()
-                        + self.to_bytes()
-                    ),
-                )
-            ]
-        ).to_bytes()
+                        core.AdvertisingData.SERVICE_DATA_16_BIT_UUID,
+                        (
+                            bytes(gatt.GATT_BROADCAST_AUDIO_ANNOUNCEMENT_SERVICE)
+                            + bytes(self)
+                        ),
+                    )
+                ]
+            )
+        )
 
 
 @dataclasses.dataclass
@@ -514,7 +513,7 @@ class BasicAudioAnnouncement:
         index: int
         codec_specific_configuration: CodecSpecificConfiguration
 
-        def to_bytes(self) -> bytes:
+        def __bytes__(self) -> bytes:
             codec_specific_configuration_bytes = bytes(
                 self.codec_specific_configuration
             )
@@ -523,9 +522,6 @@ class BasicAudioAnnouncement:
                 + codec_specific_configuration_bytes
             )
 
-        def __bytes__(self) -> bytes:
-            return self.to_bytes()
-
     @dataclasses.dataclass
     class Subgroup:
         codec_id: hci.CodingFormat
@@ -533,23 +529,20 @@ class BasicAudioAnnouncement:
         metadata: le_audio.Metadata
         bis: List[BasicAudioAnnouncement.BIS]
 
-        def to_bytes(self) -> bytes:
+        def __bytes__(self) -> bytes:
             metadata_bytes = bytes(self.metadata)
             codec_specific_configuration_bytes = bytes(
                 self.codec_specific_configuration
             )
             return (
                 bytes([len(self.bis)])
-                + self.codec_id.to_bytes()
+                + bytes(self.codec_id)
                 + bytes([len(codec_specific_configuration_bytes)])
                 + codec_specific_configuration_bytes
                 + bytes([len(metadata_bytes)])
                 + metadata_bytes
                 + b''.join(map(bytes, self.bis))
             )
-
-        def __bytes__(self) -> bytes:
-            return self.to_bytes()
 
     presentation_delay: int
     subgroups: List[BasicAudioAnnouncement.Subgroup]
@@ -607,25 +600,24 @@ class BasicAudioAnnouncement:
 
         return cls(presentation_delay, subgroups)
 
-    def to_bytes(self) -> bytes:
+    def __bytes__(self) -> bytes:
         return (
             self.presentation_delay.to_bytes(3, 'little')
             + bytes([len(self.subgroups)])
             + b''.join(map(bytes, self.subgroups))
         )
 
-    def __bytes__(self) -> bytes:
-        return self.to_bytes()
-
     def get_advertising_data(self) -> bytes:
-        return core.AdvertisingData(
-            [
-                (
-                    core.AdvertisingData.SERVICE_DATA_16_BIT_UUID,
+        return bytes(
+            core.AdvertisingData(
+                [
                     (
-                        gatt.GATT_BASIC_AUDIO_ANNOUNCEMENT_SERVICE.to_bytes()
-                        + self.to_bytes()
-                    ),
-                )
-            ]
-        ).to_bytes()
+                        core.AdvertisingData.SERVICE_DATA_16_BIT_UUID,
+                        (
+                            bytes(gatt.GATT_BASIC_AUDIO_ANNOUNCEMENT_SERVICE)
+                            + bytes(self)
+                        ),
+                    )
+                ]
+            )
+        )

--- a/bumble/sdp.py
+++ b/bumble/sdp.py
@@ -344,9 +344,6 @@ class DataElement:
         ]  # Keep a copy so we can re-serialize to an exact replica
         return result
 
-    def to_bytes(self):
-        return bytes(self)
-
     def __bytes__(self):
         # Return early if we have a cache
         if self.bytes:
@@ -623,11 +620,8 @@ class SDP_PDU:
     def init_from_bytes(self, pdu, offset):
         return HCI_Object.init_from_bytes(self, pdu, offset, self.fields)
 
-    def to_bytes(self):
-        return self.pdu
-
     def __bytes__(self):
-        return self.to_bytes()
+        return self.pdu
 
     def __str__(self):
         result = f'{color(self.name, "blue")} [TID={self.transaction_id}]'

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -298,11 +298,8 @@ class SMP_Command:
     def init_from_bytes(self, pdu: bytes, offset: int) -> None:
         return HCI_Object.init_from_bytes(self, pdu, offset, self.fields)
 
-    def to_bytes(self):
-        return self.pdu
-
     def __bytes__(self):
-        return self.to_bytes()
+        return self.pdu
 
     def __str__(self):
         result = color(self.name, 'yellow')
@@ -1949,7 +1946,7 @@ class Manager(EventEmitter):
             f'{connection.peer_address}: {command}'
         )
         cid = SMP_BR_CID if connection.transport == BT_BR_EDR_TRANSPORT else SMP_CID
-        connection.send_l2cap_pdu(cid, command.to_bytes())
+        connection.send_l2cap_pdu(cid, bytes(command))
 
     def on_smp_security_request_command(
         self, connection: Connection, request: SMP_Security_Request_Command

--- a/tests/gatt_test.py
+++ b/tests/gatt_test.py
@@ -57,7 +57,7 @@ from .test_utils import async_barrier
 
 # -----------------------------------------------------------------------------
 def basic_check(x):
-    pdu = x.to_bytes()
+    pdu = bytes(x)
     parsed = ATT_PDU.from_bytes(pdu)
     x_str = str(x)
     parsed_str = str(parsed)
@@ -74,7 +74,7 @@ def test_UUID():
     assert str(u) == '61A3512C-09BE-4DDC-A6A6-0B03667AAFC6'
     v = UUID(str(u))
     assert str(v) == '61A3512C-09BE-4DDC-A6A6-0B03667AAFC6'
-    w = UUID.from_bytes(v.to_bytes())
+    w = UUID.from_bytes(bytes(v))
     assert str(w) == '61A3512C-09BE-4DDC-A6A6-0B03667AAFC6'
 
     u1 = UUID.from_16_bits(0x1234)

--- a/tests/hci_test.py
+++ b/tests/hci_test.py
@@ -75,13 +75,13 @@ from bumble.hci import (
 
 
 def basic_check(x):
-    packet = x.to_bytes()
+    packet = bytes(x)
     print(packet.hex())
     parsed = HCI_Packet.from_bytes(packet)
     x_str = str(x)
     parsed_str = str(parsed)
     print(x_str)
-    parsed_bytes = parsed.to_bytes()
+    parsed_bytes = bytes(parsed)
     assert x_str == parsed_str
     assert packet == parsed_bytes
 
@@ -188,7 +188,7 @@ def test_HCI_Command_Complete_Event():
         return_parameters=bytes([7]),
     )
     basic_check(event)
-    event = HCI_Packet.from_bytes(event.to_bytes())
+    event = HCI_Packet.from_bytes(bytes(event))
     assert event.return_parameters == 7
 
     # With a simple status as an integer status
@@ -562,7 +562,7 @@ def test_iso_data_packet():
         '6281bc77ed6a3206d984bcdabee6be831c699cb50e2'
     )
 
-    assert packet.to_bytes() == data
+    assert bytes(packet) == data
 
 
 # -----------------------------------------------------------------------------

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -240,7 +240,7 @@ async def test_self_gatt():
     result = await peer.discover_included_services(result[0])
     assert len(result) == 2
     # Service UUID is only present when the UUID is 16-bit Bluetooth UUID
-    assert result[1].uuid.to_bytes() == s3.uuid.to_bytes()
+    assert bytes(result[1].uuid) == bytes(s3.uuid)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The use of `to_bytes` should be reserved for cases where an argument is needed (like `int.to_bytes()`). For all other cases, `__bytes__` should be used.
For legacy reasons, the code base still had a few places where `to_bytes` was called (and classes where both `__bytes__` and `to_bytes` were defined).
This PR cleans up these cases. 