### PR TITLE
Add maximum encryption key size to PairingDelegate

### DIFF
--- a/bumble/pairing.py
+++ b/bumble/pairing.py
@@ -139,16 +139,19 @@ class PairingDelegate:
     io_capability: IoCapability
     local_initiator_key_distribution: KeyDistribution
     local_responder_key_distribution: KeyDistribution
+    maximum_encryption_key_size: int
 
     def __init__(
         self,
         io_capability: IoCapability = NO_OUTPUT_NO_INPUT,
         local_initiator_key_distribution: KeyDistribution = DEFAULT_KEY_DISTRIBUTION,
         local_responder_key_distribution: KeyDistribution = DEFAULT_KEY_DISTRIBUTION,
+        maximum_encryption_key_size: int = 16
     ) -> None:
         self.io_capability = io_capability
         self.local_initiator_key_distribution = local_initiator_key_distribution
         self.local_responder_key_distribution = local_responder_key_distribution
+        self.maximum_encryption_key_size = maximum_encryption_key_size
 
     @property
     def classic_io_capability(self) -> int:

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -695,6 +695,7 @@ class Session:
         self.ltk_ediv = 0
         self.ltk_rand = bytes(8)
         self.link_key: Optional[bytes] = None
+        self.maximum_encryption_key_size: int = 0
         self.initiator_key_distribution: int = 0
         self.responder_key_distribution: int = 0
         self.peer_random_value: Optional[bytes] = None
@@ -740,6 +741,10 @@ class Session:
             )
         else:
             self.pairing_result = None
+
+        self.maximum_encryption_key_size = (
+            pairing_config.delegate.maximum_encryption_key_size
+        )
 
         # Key Distribution (default values before negotiation)
         self.initiator_key_distribution = (
@@ -993,7 +998,7 @@ class Session:
             io_capability=self.io_capability,
             oob_data_flag=self.oob_data_flag,
             auth_req=self.auth_req,
-            maximum_encryption_key_size=16,
+            maximum_encryption_key_size=self.maximum_encryption_key_size,
             initiator_key_distribution=self.initiator_key_distribution,
             responder_key_distribution=self.responder_key_distribution,
         )
@@ -1005,7 +1010,7 @@ class Session:
             io_capability=self.io_capability,
             oob_data_flag=self.oob_data_flag,
             auth_req=self.auth_req,
-            maximum_encryption_key_size=16,
+            maximum_encryption_key_size=self.maximum_encryption_key_size,
             initiator_key_distribution=self.initiator_key_distribution,
             responder_key_distribution=self.responder_key_distribution,
         )


### PR DESCRIPTION
So far the maxmium encryption key size has been hardcoded to 16 bytes in 'send_pairing_request_command()' and 'send_pairing_response_comman()'. By making this configurable via the PairingDelegate, one can test how devices respond to smaller encryption key sizes. Default remains 16 bytes.