### PR TITLE
move pandora deps to development

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ".[build,test,development,pandora]"
+        python -m pip install ".[build,test,development]"
     - name: Check
       run: |
         invoke project.pre-commit

--- a/.github/workflows/python-avatar.yml
+++ b/.github/workflows/python-avatar.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[avatar,pandora]
+          python -m pip install .[avatar]
       - name: Rootcanal
         run: nohup python -m rootcanal > rootcanal.log &
       - name: Test

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,6 +91,7 @@ test =
     coverage >= 6.4
 development =
     black == 24.3
+    bt-test-interfaces >= 0.0.6
     grpcio-tools >= 1.62.1
     invoke >= 1.7.3
     mobly >= 1.12.2
@@ -105,8 +106,6 @@ development =
 avatar =
     pandora-avatar == 0.0.10
     rootcanal == 1.10.0 ; python_version>='3.10'
-pandora =
-    bt-test-interfaces >= 0.0.6
 documentation =
     mkdocs >= 1.4.0
     mkdocs-material >= 8.5.6


### PR DESCRIPTION
This way, type checking works for any user with the `development` dependencies.