### PR TITLE
update cryptography dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "aiohttp ~= 3.8; platform_system!='Emscripten'",
     "appdirs >= 1.4; platform_system!='Emscripten'",
     "click >= 8.1.3; platform_system!='Emscripten'",
-    "cryptography == 39; platform_system!='Emscripten'",
+    "cryptography >= 39; platform_system!='Emscripten'",
     # Pyodide bundles a version of cryptography that is built for wasm, which may not match the
     # versions available on PyPI. Relax the version requirement since it's better than being
     # completely unable to import the package in case of version mismatch.


### PR DESCRIPTION
To allow users to have versions of the cryptography dependency that are >= 39