### PR TITLE
Avoid cancelling futures

### DIFF
--- a/bumble/core.py
+++ b/bumble/core.py
@@ -16,7 +16,7 @@
 # Imports
 # -----------------------------------------------------------------------------
 from __future__ import annotations
-import dataclasses
+import asyncio
 import enum
 import struct
 from typing import List, Optional, Tuple, Union, cast, Dict
@@ -158,6 +158,14 @@ class OutOfResourcesError(BaseBumbleError, RuntimeError):
 
 class UnreachableError(BaseBumbleError):
     """The code path raising this error should be unreachable."""
+
+
+class CancelledError(BaseBumbleError, asyncio.CancelledError):
+    """Operation has been cancelled or aborted."""
+
+
+class BearerLostError(BaseBumbleError):
+    """Bearer transport (ACL, L2CAP Channel) has been terminated or lost."""
 
 
 class ConnectionError(BaseError):  # pylint: disable=redefined-builtin

--- a/bumble/gatt_client.py
+++ b/bumble/gatt_client.py
@@ -1060,9 +1060,11 @@ class Client:
                 )
             )
 
-    def on_disconnection(self, _) -> None:
+    def on_disconnection(self, reason: int) -> None:
         if self.pending_response and not self.pending_response.done():
-            self.pending_response.cancel()
+            self.pending_response.set_exception(
+                core.BearerLostError(f"Connection terminated, reason={reason}")
+            )
 
     def on_gatt_pdu(self, att_pdu: ATT_PDU) -> None:
         logger.debug(

--- a/bumble/rfcomm.py
+++ b/bumble/rfcomm.py
@@ -727,10 +727,10 @@ class DLC(EventEmitter):
     def abort(self) -> None:
         logger.debug(f'aborting DLC: {self}')
         if self.connection_result:
-            self.connection_result.cancel()
+            self.connection_result.set_exception(core.CancelledError("Aborted"))
             self.connection_result = None
         if self.disconnection_result:
-            self.disconnection_result.cancel()
+            self.disconnection_result.set_exception(core.CancelledError("Aborted"))
             self.disconnection_result = None
         self.change_state(DLC.State.RESET)
         self.emit('close')
@@ -1011,10 +1011,12 @@ class Multiplexer(EventEmitter):
     def on_l2cap_channel_close(self) -> None:
         logger.debug('L2CAP channel closed, cleaning up')
         if self.open_result:
-            self.open_result.cancel()
+            self.open_result.set_exception(core.BearerLostError("L2CAP channel closed"))
             self.open_result = None
         if self.disconnection_result:
-            self.disconnection_result.cancel()
+            self.disconnection_result.set_exception(
+                core.BearerLostError("L2CAP channel closed")
+            )
             self.disconnection_result = None
         for dlc in self.dlcs.values():
             dlc.abort()

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -25,6 +25,7 @@ from bumble.core import (
     BT_BR_EDR_TRANSPORT,
     BT_LE_TRANSPORT,
     BT_PERIPHERAL_ROLE,
+    CancelledError,
     ConnectionParameters,
 )
 from bumble.device import (
@@ -259,11 +260,8 @@ async def test_flush():
     d0 = Device(host=Host(None, None))
     task = d0.abort_on('flush', asyncio.sleep(10000))
     await d0.host.flush()
-    try:
+    with pytest.raises(CancelledError):
         await task
-        assert False
-    except asyncio.CancelledError:
-        pass
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Cancelling a future doesn't provide enough information to its awaiter, and may leak `asyncio.CancelledError` to out of APIs.