### PR TITLE
support multiple event factories

### DIFF
--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -5167,7 +5167,7 @@ class HCI_Event(HCI_Packet):
 
             # No factory, or the factory could not create an instance,
             # return a generic vendor event
-            return HCI_Event(event_code, parameters)
+            return HCI_Vendor_Event(data=parameters)
         else:
             subclass = HCI_Event.event_classes.get(event_code)
             if subclass is None:

--- a/bumble/vendor/android/hci.py
+++ b/bumble/vendor/android/hci.py
@@ -299,7 +299,7 @@ class HCI_Android_Vendor_Event(HCI_Extended_Event):
 
 
 HCI_Android_Vendor_Event.register_subevents(globals())
-HCI_Event.vendor_factory = HCI_Android_Vendor_Event.subclass_from_parameters
+HCI_Event.add_vendor_factory(HCI_Android_Vendor_Event.subclass_from_parameters)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
While there's no way to ensure the uniqueness of HCI vendor event codes across vendors, it is still possible to have vendor event factories that don't overlap (by design), such as the generic set of Android vendor HCI events which multiple vendors do implement (and in that case the vendors ensure that they don't re-use the same event codes for other events).
This change allows having multiple vendor factories, which will be invoked in registration order when an HCI vendor event is encountered, instead of a single factory. It is up to the caller to ensure that they do not register factories with overlapping IDs.