### PR TITLE
Fix: _IsoLink.write() struct.exception

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1406,7 +1406,7 @@ class _IsoLink:
                 iso_sdu_fragment=sdu,
             )
         )
-        self.packet_sequence_number += 1
+        self.packet_sequence_number = (self.packet_sequence_number + 1) % 0x10000
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
`_IsoLink.write()` raises  `struct.error: 'H' format requires 0 <= number <= 65535` exception. Further discussed [here](https://github.com/google/bumble/issues/621#issue-2779021902).