### PR TITLE
Update device.py - Fix scan_interval param in hci.HCI_LE_Set_Extended_Scan_Parameters_Command

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -2909,7 +2909,7 @@ class Device(CompositeEventEmitter):
                     scanning_filter_policy=scanning_filter_policy,
                     scanning_phys=scanning_phys_bits,
                     scan_types=[scan_type] * scanning_phy_count,
-                    scan_intervals=[int(scan_window / 0.625)] * scanning_phy_count,
+                    scan_intervals=[int(scan_interval / 0.625)] * scanning_phy_count,
                     scan_windows=[int(scan_window / 0.625)] * scanning_phy_count,
                 ),
                 check_result=True,


### PR DESCRIPTION
Fix `scan_interval ` for the `hci.HCI_LE_Set_Extended_Scan_Parameters_Command` used for setting scan params (see https://github.com/google/bumble/issues/625)