### PR TITLE
auracast audio io

### DIFF
--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -953,8 +953,8 @@ async def run_transmit(
             )
 
             iso_queues = [
-                bumble.device.IsoPacketStream(big.bis_links[0], 5),
-                bumble.device.IsoPacketStream(big.bis_links[1], 5),
+                bumble.device.IsoPacketStream(big.bis_links[0], 64),
+                bumble.device.IsoPacketStream(big.bis_links[1], 64),
             ]
 
             def on_flow():

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -675,7 +675,7 @@ async def run_receive(
     try:
         if not audio_io.check_audio_output(output):
             return
-    except (ValueError, ImportError, OSError) as error:
+    except ValueError as error:
         print(error)
         return
 
@@ -820,7 +820,7 @@ async def run_transmit(
     try:
         if not audio_io.check_audio_input(input):
             return
-    except (ValueError, ImportError, OSError) as error:
+    except ValueError as error:
         print(error)
         return
 

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -932,6 +932,10 @@ async def run_transmit(
             )
             lc3_frame_samples = encoder.get_frame_samples()
             lc3_frame_size = encoder.get_frame_bytes(bitrate)
+            print(
+                f'Encoding with {lc3_frame_samples} '
+                f'PCM samples per {lc3_frame_size} byte frame'
+            )
 
             print('Setup BIG')
             big = await device.create_big(

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -960,24 +960,12 @@ async def run_transmit(
 
         async with contextlib.aclosing(audio_input):
             frame_count = 0
-            # start_time = time.time()
             async for pcm_frame in audio_input.frames(lc3_frame_samples):
-                # now = time.time()
-                # if (
-                #     target_time := (
-                #         start_time
-                #         + frame_count * AURACAST_DEFAULT_FRAME_DURATION / 1_000_000
-                #     )
-                # ) >= now:
-                #     await asyncio.sleep(target_time - now)
-
                 lc3_frame = encoder.encode(
                     pcm_frame, num_bytes=2 * lc3_frame_size, bit_depth=16
                 )
 
                 mid = len(lc3_frame) // 2
-                # big.bis_links[0].write(lc3_frame[:mid])
-                # big.bis_links[1].write(lc3_frame[mid:])
                 await iso_queues[0].write(lc3_frame[:mid])
                 await iso_queues[1].write(lc3_frame[mid:])
 

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -924,6 +924,14 @@ async def run_transmit(
             if pcm_format.channels != 2:
                 print("Only 2 channels PCM configurations are supported")
                 return
+            if pcm_format.sample_type == audio_io.PcmFormat.SampleType.INT16:
+                pcm_bit_depth = 16
+            elif pcm_format.sample_type == audio_io.PcmFormat.SampleType.FLOAT32:
+                pcm_bit_depth = None
+            else:
+                print("Only INT16 and FLOAT32 sample types are supported")
+                return
+
             encoder = lc3.Encoder(
                 frame_duration_us=AURACAST_DEFAULT_FRAME_DURATION,
                 sample_rate_hz=AURACAST_DEFAULT_SAMPLE_RATE,
@@ -971,7 +979,7 @@ async def run_transmit(
             frame_count = 0
             async for pcm_frame in audio_input.frames(lc3_frame_samples):
                 lc3_frame = encoder.encode(
-                    pcm_frame, num_bytes=2 * lc3_frame_size, bit_depth=16
+                    pcm_frame, num_bytes=2 * lc3_frame_size, bit_depth=pcm_bit_depth
                 )
 
                 mid = len(lc3_frame) // 2
@@ -1150,7 +1158,8 @@ def receive(
         "Use 'auto' for .wav files, or for the default setting with the devices. "
         "For other inputs, the format is specified as "
         "<sample-type>,<sample-rate>,<channels> (supported <sample-type>: 'int16le' "
-        "for 16 bit signed integers with little-endian byte order)"
+        "for 16-bit signed integers with little-endian byte order or 'float32le' for "
+        "32-bit floating point with little-endian byte order)"
     ),
 )
 @click.option(

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -1195,7 +1195,7 @@ def transmit(
     input,
     input_format,
 ):
-    """Transmit a broadcast source."""
+    """Transmit a broadcast source"""
     if manufacturer_data:
         vendor_id_str, data_hex = manufacturer_data.split(':')
         vendor_id = int(vendor_id_str)

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -675,7 +675,7 @@ async def run_receive(
     try:
         if not audio_io.check_audio_output(output):
             return
-    except ValueError as error:
+    except (ValueError, ImportError, OSError) as error:
         print(error)
         return
 
@@ -820,7 +820,7 @@ async def run_transmit(
     try:
         if not audio_io.check_audio_input(input):
             return
-    except ValueError as error:
+    except (ValueError, ImportError, OSError) as error:
         print(error)
         return
 

--- a/bumble/audio/__init__.py
+++ b/bumble/audio/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Imports
+# -----------------------------------------------------------------------------

--- a/bumble/audio/io.py
+++ b/bumble/audio/io.py
@@ -23,15 +23,19 @@ from concurrent.futures import ThreadPoolExecutor
 import dataclasses
 import enum
 import logging
+import pathlib
 from typing import (
     AsyncGenerator,
     BinaryIO,
     TYPE_CHECKING,
 )
+import sys
 import wave
 
+from bumble.colors import color
+
 if TYPE_CHECKING:
-    import sounddevice
+    import sounddevice  # type: ignore[import-untyped]
 
 
 # -----------------------------------------------------------------------------
@@ -78,9 +82,10 @@ def check_audio_output(output: str) -> bool:
     if output == 'device' or output.startswith('device:'):
         try:
             import sounddevice
-        except ImportError as exc:
+        except (ImportError, OSError) as exc:
             raise ValueError(
-                'audio output not available (sounddevice python module not installed)'
+                'audio output not available '
+                '(sounddevice python module not installed or failed to load)'
             ) from exc
 
         if output == 'device':
@@ -289,9 +294,10 @@ def check_audio_input(input: str) -> bool:
     if input == 'device' or input.startswith('device:'):
         try:
             import sounddevice
-        except ImportError as exc:
+        except (ImportError, OSError) as exc:
             raise ValueError(
-                'audio input not available (sounddevice python module not installed)'
+                'audio input not available '
+                '(sounddevice python module not installed or failed to load)'
             ) from exc
 
         if input == 'device':

--- a/bumble/audio/io.py
+++ b/bumble/audio/io.py
@@ -1,0 +1,534 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Imports
+# -----------------------------------------------------------------------------
+from __future__ import annotations
+
+import asyncio
+import abc
+from concurrent.futures import ThreadPoolExecutor
+import dataclasses
+import enum
+import logging
+from typing import (
+    AsyncGenerator,
+    BinaryIO,
+    TYPE_CHECKING,
+)
+import wave
+
+if TYPE_CHECKING:
+    import sounddevice
+
+
+# -----------------------------------------------------------------------------
+# Logging
+# -----------------------------------------------------------------------------
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Classes
+# -----------------------------------------------------------------------------
+@dataclasses.dataclass
+class PcmFormat:
+    class Endianness(enum.Enum):
+        LITTLE = 0
+        BIG = 1
+
+    class SampleType(enum.Enum):
+        FLOAT32 = 0
+        INT16 = 1
+
+    endianness: Endianness
+    sample_type: SampleType
+    sample_rate: int
+    channels: int
+
+    @classmethod
+    def from_str(cls, format_str: str) -> PcmFormat:
+        endianness = cls.Endianness.LITTLE  # Others not yet supported.
+        sample_type_str, sample_rate_str, channels_str = format_str.split(',')
+        if sample_type_str == 'int16le':
+            sample_type = cls.SampleType.INT16
+        elif sample_rate_str == 'float32le':
+            sample_type = cls.SampleType.FLOAT32
+        else:
+            raise ValueError(f'sample type {sample_type_str} not supported')
+        sample_rate = int(sample_rate_str)
+        channels = int(channels_str)
+
+        return cls(endianness, sample_type, sample_rate, channels)
+
+
+def check_audio_output(output: str) -> bool:
+    if output == 'device' or output.startswith('device:'):
+        try:
+            import sounddevice
+        except ImportError as exc:
+            raise ValueError(
+                'audio output not available (sounddevice python module not installed)'
+            ) from exc
+
+        if output == 'device':
+            # Default device
+            return True
+
+        # Specific device
+        device = output[7:]
+        if device == '?':
+            print(color('Audio Devices:', 'yellow'))
+            for device_info in [
+                device_info
+                for device_info in sounddevice.query_devices()
+                if device_info['max_output_channels'] > 0
+            ]:
+                device_index = device_info['index']
+                is_default = (
+                    color(' [default]', 'green')
+                    if sounddevice.default.device[1] == device_index
+                    else ''
+                )
+                print(
+                    f'{color(device_index, "cyan")}: {device_info["name"]}{is_default}'
+                )
+            return False
+
+        try:
+            device_info = sounddevice.query_devices(int(device))
+        except sounddevice.PortAudioError as exc:
+            raise ValueError('No such audio device') from exc
+
+        if device_info['max_output_channels'] < 1:
+            raise ValueError(
+                f'Device {device} ({device_info["name"]}) does not have an output'
+            )
+
+    return True
+
+
+async def create_audio_output(output: str) -> AudioOutput:
+    if output == 'stdout':
+        return StreamAudioOutput(sys.stdout.buffer)
+
+    if output == 'device' or output.startswith('device:'):
+        device_name = '' if output == 'device' else output[7:]
+        return SoundDeviceAudioOutput(device_name)
+
+    if output == 'ffplay':
+        return SubprocessAudioOutput(
+            command=(
+                'ffplay -probesize 32 -fflags nobuffer -analyzeduration 0 '
+                '-ar {sample_rate} '
+                '-ch_layout {channel_layout} '
+                '-f f32le pipe:0'
+            )
+        )
+
+    if output.startswith('file:'):
+        return FileAudioOutput(output[5:])
+
+    raise ValueError('unsupported audio output')
+
+
+class AudioOutput(abc.ABC):
+    """Audio output to which PCM samples can be written."""
+
+    async def open(self, pcm_format: PcmFormat) -> None:
+        """Start the output."""
+
+    @abc.abstractmethod
+    def write(self, pcm_samples: bytes) -> None:
+        """Write PCM samples. Must not block."""
+
+    async def aclose(self) -> None:
+        """Close the output."""
+
+
+class ThreadedAudioOutput(AudioOutput):
+    """Base class for AudioOutput classes that may need to call blocking functions.
+
+    The actual writing is performed in a thread, so as to ensure that calling write()
+    does not block the caller.
+    """
+
+    def __init__(self) -> None:
+        self._thread_pool = ThreadPoolExecutor(1)
+        self._pcm_samples: asyncio.Queue[bytes] = asyncio.Queue()
+        self._write_task = asyncio.create_task(self._write_loop())
+
+    async def _write_loop(self) -> None:
+        while True:
+            pcm_samples = await self._pcm_samples.get()
+            await asyncio.get_running_loop().run_in_executor(
+                self._thread_pool, self._write, pcm_samples
+            )
+
+    @abc.abstractmethod
+    def _write(self, pcm_samples: bytes) -> None:
+        """This method does the actual writing and can block."""
+
+    def write(self, pcm_samples: bytes) -> None:
+        self._pcm_samples.put_nowait(pcm_samples)
+
+    def _close(self) -> None:
+        """This method does the actual closing and can block."""
+
+    async def aclose(self) -> None:
+        await asyncio.get_running_loop().run_in_executor(self._thread_pool, self._close)
+        self._write_task.cancel()
+        self._thread_pool.shutdown()
+
+
+class SoundDeviceAudioOutput(ThreadedAudioOutput):
+    def __init__(self, device_name: str) -> None:
+        super().__init__()
+        self._device = int(device_name) if device_name else None
+        self._stream: sounddevice.RawOutputStream | None = None
+
+    async def open(self, pcm_format: PcmFormat) -> None:
+        import sounddevice
+
+        self._stream = sounddevice.RawOutputStream(
+            samplerate=pcm_format.sample_rate,
+            device=self._device,
+            channels=pcm_format.channels,
+            dtype='float32',
+        )
+        self._stream.start()
+
+    def _write(self, pcm_samples: bytes) -> None:
+        if self._stream is None:
+            return
+
+        try:
+            self._stream.write(pcm_samples)
+        except Exception as error:
+            print(f'Sound device error: {error}')
+            raise
+
+    def _close(self):
+        self._stream.stop()
+        self._stream = None
+
+
+class StreamAudioOutput(ThreadedAudioOutput):
+    """AudioOutput where PCM samples are written to a stream that may block."""
+
+    def __init__(self, stream: BinaryIO) -> None:
+        super().__init__()
+        self._stream = stream
+
+    def _write(self, pcm_samples: bytes) -> None:
+        self._stream.write(pcm_samples)
+        self._stream.flush()
+
+
+class FileAudioOutput(StreamAudioOutput):
+    """AudioOutput where PCM samples are written to a file."""
+
+    def __init__(self, filename: str) -> None:
+        self._file = open(filename, "wb")
+        super().__init__(self._file)
+
+    async def shutdown(self):
+        self._file.close()
+        return await super().shutdown()
+
+
+class SubprocessAudioOutput(AudioOutput):
+    """AudioOutput where audio samples are written to a subprocess via stdin."""
+
+    def __init__(self, command: str) -> None:
+        self._command = command
+        self._subprocess: asyncio.subprocess.Process | None
+
+    async def open(self, pcm_format: PcmFormat) -> None:
+        if pcm_format.channels == 1:
+            channel_layout = 'mono'
+        elif pcm_format.channels == 2:
+            channel_layout = 'stereo'
+        else:
+            raise ValueError(f'{pcm_format.channels} channels not supported')
+
+        command = self._command.format(
+            sample_rate=pcm_format.sample_rate, channel_layout=channel_layout
+        )
+        self._subprocess = await asyncio.create_subprocess_shell(
+            command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+    def write(self, pcm_samples: bytes) -> None:
+        if self._subprocess is None or self._subprocess.stdin is None:
+            return
+
+        self._subprocess.stdin.write(pcm_samples)
+
+    async def aclose(self):
+        if self._subprocess:
+            self._subprocess.terminate()
+
+
+def check_audio_input(input: str) -> bool:
+    if input == 'device' or input.startswith('device:'):
+        try:
+            import sounddevice
+        except ImportError as exc:
+            raise ValueError(
+                'audio input not available (sounddevice python module not installed)'
+            ) from exc
+
+        if input == 'device':
+            # Default device
+            return True
+
+        # Specific device
+        device = input[7:]
+        if device == '?':
+            print(color('Audio Devices:', 'yellow'))
+            for device_info in [
+                device_info
+                for device_info in sounddevice.query_devices()
+                if device_info['max_input_channels'] > 0
+            ]:
+                device_index = device_info["index"]
+                is_mono = device_info['max_input_channels'] == 1
+                max_channels = color(f'[{"mono" if is_mono else "stereo"}]', 'cyan')
+                is_default = (
+                    color(' [default]', 'green')
+                    if sounddevice.default.device[0] == device_index
+                    else ''
+                )
+                print(
+                    f'{color(device_index, "cyan")}: {device_info["name"]}'
+                    f' {max_channels}{is_default}'
+                )
+            return False
+
+        try:
+            device_info = sounddevice.query_devices(int(device))
+        except sounddevice.PortAudioError as exc:
+            raise ValueError('No such audio device') from exc
+
+        if device_info['max_input_channels'] < 1:
+            raise ValueError(
+                f'Device {device} ({device_info["name"]}) does not have an input'
+            )
+
+    return True
+
+
+async def create_audio_input(input: str, input_format: str) -> AudioInput:
+    pcm_format: PcmFormat | None
+    if input_format == 'auto':
+        pcm_format = None
+    else:
+        pcm_format = PcmFormat.from_str(input_format)
+
+    if input == 'stdin':
+        if not pcm_format:
+            raise ValueError('input format details required for stdin')
+        return StreamAudioInput(sys.stdin.buffer, pcm_format)
+
+    if input == 'device' or input.startswith('device:'):
+        if not pcm_format:
+            raise ValueError('input format details required for device')
+        device_name = '' if input == 'device' else input[7:]
+        return SoundDeviceAudioInput(device_name, pcm_format)
+
+    # If there's no file: prefix, check if we can assume it is a file.
+    if pathlib.Path(input).is_file():
+        input = 'file:' + input
+
+    if input.startswith('file:'):
+        filename = input[5:]
+        if filename.endswith('.wav'):
+            if input_format != 'auto':
+                raise ValueError(".wav file only supported with 'auto' format")
+            return WaveAudioInput(filename)
+
+        if pcm_format is None:
+            raise ValueError('input format details required for raw PCM files')
+        return FileAudioInput(filename, pcm_format)
+
+    raise ValueError('input not supported')
+
+
+class AudioInput(abc.ABC):
+    """Audio input that produces PCM samples."""
+
+    @abc.abstractmethod
+    async def open(self) -> PcmFormat:
+        """Open the input."""
+
+    @abc.abstractmethod
+    def frames(self, frame_size: int) -> AsyncGenerator[bytes]:
+        """Generate one frame of PCM samples. Must not block."""
+
+    async def aclose(self) -> None:
+        """Close the input."""
+
+
+class ThreadedAudioInput(AudioInput):
+    """Base class for AudioInput implementation where reading samples may block."""
+
+    def __init__(self) -> None:
+        self._thread_pool = ThreadPoolExecutor(1)
+        self._pcm_samples: asyncio.Queue[bytes] = asyncio.Queue()
+
+    @abc.abstractmethod
+    def _read(self, frame_size: int) -> bytes:
+        pass
+
+    @abc.abstractmethod
+    def _open(self) -> PcmFormat:
+        pass
+
+    def _close(self) -> None:
+        pass
+
+    async def open(self) -> PcmFormat:
+        return await asyncio.get_running_loop().run_in_executor(
+            self._thread_pool, self._open
+        )
+
+    async def frames(self, frame_size: int) -> AsyncGenerator[bytes]:
+        while pcm_sample := await asyncio.get_running_loop().run_in_executor(
+            self._thread_pool, self._read, frame_size
+        ):
+            yield pcm_sample
+
+    async def aclose(self) -> None:
+        await asyncio.get_running_loop().run_in_executor(self._thread_pool, self._close)
+        self._thread_pool.shutdown()
+
+
+class WaveAudioInput(ThreadedAudioInput):
+    """Audio input that reads PCM samples from a .wav file."""
+
+    def __init__(self, filename: str) -> None:
+        super().__init__()
+        self._filename = filename
+        self._wav: wave.Wave_read | None = None
+        self._bytes_read = 0
+
+    def _open(self) -> PcmFormat:
+        self._wav = wave.open(self._filename, 'rb')
+        if self._wav.getsampwidth() != 2:
+            raise ValueError('sample width not supported')
+        return PcmFormat(
+            PcmFormat.Endianness.LITTLE,
+            PcmFormat.SampleType.INT16,
+            self._wav.getframerate(),
+            self._wav.getnchannels(),
+        )
+
+    def _read(self, frame_size: int) -> bytes:
+        if not self._wav:
+            return b''
+
+        pcm_samples = self._wav.readframes(frame_size)
+        if not pcm_samples and self._bytes_read:
+            # Loop around.
+            self._wav.rewind()
+            self._bytes_read = 0
+            pcm_samples = self._wav.readframes(frame_size)
+
+        self._bytes_read += len(pcm_samples)
+        return pcm_samples
+
+    def _close(self) -> None:
+        if self._wav:
+            self._wav.close()
+
+
+class StreamAudioInput(ThreadedAudioInput):
+    """AudioInput where samples are read from a raw PCM stream that may block."""
+
+    def __init__(self, stream: BinaryIO, pcm_format: PcmFormat) -> None:
+        super().__init__()
+        self._stream = stream
+        self._pcm_format = pcm_format
+
+    def _open(self) -> PcmFormat:
+        return self._pcm_format
+
+    def _read(self, frame_size: int) -> bytes:
+        return self._stream.read(frame_size * self._pcm_format.channels * 2)
+
+
+class FileAudioInput(StreamAudioInput):
+    """AudioInput where PCM samples are read from a raw PCM file."""
+
+    def __init__(self, filename: str, pcm_format: PcmFormat) -> None:
+        self._stream = open(filename, "rb")
+        super().__init__(self._stream, pcm_format)
+
+    def _read(self, frame_size: int) -> bytes:
+        return self._stream.read(frame_size * self._pcm_format.channels * 2)
+
+    def _close(self) -> None:
+        self._stream.close()
+
+
+class SoundDeviceAudioInput(ThreadedAudioInput):
+    def __init__(self, device_name: str, pcm_format: PcmFormat) -> None:
+        super().__init__()
+        self._device = int(device_name) if device_name else None
+        self._pcm_format = pcm_format
+        self._stream: sounddevice.RawInputStream | None = None
+
+    def _open(self) -> PcmFormat:
+        import sounddevice
+
+        self._stream = sounddevice.RawInputStream(
+            samplerate=self._pcm_format.sample_rate,
+            device=self._device,
+            channels=self._pcm_format.channels,
+            dtype='int16',
+        )
+        self._stream.start()
+
+        return PcmFormat(
+            PcmFormat.Endianness.LITTLE,
+            PcmFormat.SampleType.INT16,
+            self._pcm_format.sample_rate,
+            2,
+        )
+
+    def _read(self, frame_size: int) -> bytes:
+        if not self._stream:
+            return b''
+        pcm_buffer, overflowed = self._stream.read(frame_size)
+        if overflowed:
+            logger.warning("input overflow")
+
+        # Convert the buffer to stereo if needed
+        if self._pcm_format.channels == 1:
+            stereo_buffer = bytearray()
+            for i in range(frame_size):
+                sample = pcm_buffer[i * 2 : i * 2 + 2]
+                stereo_buffer += sample + sample
+            return stereo_buffer
+
+        return bytes(pcm_buffer)
+
+    def _close(self):
+        self._stream.stop()
+        self._stream = None

--- a/bumble/audio/io.py
+++ b/bumble/audio/io.py
@@ -88,7 +88,9 @@ def check_audio_output(output: str) -> bool:
             ) from exc
         except OSError as exc:
             raise ValueError(
-                'audio output not available (sounddevice python module failed to load)'
+                'audio output not available '
+                '(sounddevice python module failed to load: '
+                f'{exc})'
             ) from exc
 
         if output == 'device':
@@ -303,7 +305,9 @@ def check_audio_input(input: str) -> bool:
             ) from exc
         except OSError as exc:
             raise ValueError(
-                'audio input not available (sounddevice python module failed to load)'
+                'audio input not available '
+                '(sounddevice python module failed to load: '
+                f'{exc})'
             ) from exc
 
         if input == 'device':

--- a/bumble/audio/io.py
+++ b/bumble/audio/io.py
@@ -210,7 +210,7 @@ class SoundDeviceAudioOutput(ThreadedAudioOutput):
         self._stream: sounddevice.RawOutputStream | None = None
 
     async def open(self, pcm_format: PcmFormat) -> None:
-        import sounddevice
+        import sounddevice  # pylint: disable=import-error
 
         self._stream = sounddevice.RawOutputStream(
             samplerate=pcm_format.sample_rate,
@@ -298,7 +298,7 @@ class SubprocessAudioOutput(AudioOutput):
 def check_audio_input(input: str) -> bool:
     if input == 'device' or input.startswith('device:'):
         try:
-            import sounddevice
+            import sounddevice  # pylint: disable=import-error
         except ImportError as exc:
             raise ValueError(
                 'audio input not available (sounddevice python module not installed)'
@@ -511,7 +511,7 @@ class SoundDeviceAudioInput(ThreadedAudioInput):
         self._stream: sounddevice.RawInputStream | None = None
 
     def _open(self) -> PcmFormat:
-        import sounddevice
+        import sounddevice  # pylint: disable=import-error
 
         self._stream = sounddevice.RawInputStream(
             samplerate=self._pcm_format.sample_rate,

--- a/bumble/audio/io.py
+++ b/bumble/audio/io.py
@@ -82,10 +82,13 @@ def check_audio_output(output: str) -> bool:
     if output == 'device' or output.startswith('device:'):
         try:
             import sounddevice
-        except (ImportError, OSError) as exc:
+        except ImportError as exc:
             raise ValueError(
-                'audio output not available '
-                '(sounddevice python module not installed or failed to load)'
+                'audio output not available (sounddevice python module not installed)'
+            ) from exc
+        except OSError as exc:
+            raise ValueError(
+                'audio output not available (sounddevice python module failed to load)'
             ) from exc
 
         if output == 'device':
@@ -294,10 +297,13 @@ def check_audio_input(input: str) -> bool:
     if input == 'device' or input.startswith('device:'):
         try:
             import sounddevice
-        except (ImportError, OSError) as exc:
+        except ImportError as exc:
             raise ValueError(
-                'audio input not available '
-                '(sounddevice python module not installed or failed to load)'
+                'audio input not available (sounddevice python module not installed)'
+            ) from exc
+        except OSError as exc:
+            raise ValueError(
+                'audio input not available (sounddevice python module failed to load)'
             ) from exc
 
         if input == 'device':

--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -315,6 +315,7 @@ GATT_CENTRAL_ADDRESS_RESOLUTION__CHARACTERISTIC                = UUID.from_16_bi
 GATT_CLIENT_SUPPORTED_FEATURES_CHARACTERISTIC                  = UUID.from_16_bits(0x2B29, 'Client Supported Features')
 GATT_DATABASE_HASH_CHARACTERISTIC                              = UUID.from_16_bits(0x2B2A, 'Database Hash')
 GATT_SERVER_SUPPORTED_FEATURES_CHARACTERISTIC                  = UUID.from_16_bits(0x2B3A, 'Server Supported Features')
+GATT_LE_GATT_SECURITY_LEVELS_CHARACTERISTIC                    = UUID.from_16_bits(0x2BF5, 'E GATT Security Levels')
 
 # fmt: on
 # pylint: enable=line-too-long

--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -323,8 +323,6 @@ GATT_SERVER_SUPPORTED_FEATURES_CHARACTERISTIC                  = UUID.from_16_bi
 # -----------------------------------------------------------------------------
 # Utils
 # -----------------------------------------------------------------------------
-
-
 def show_services(services: Iterable[Service]) -> None:
     for service in services:
         print(color(str(service), 'cyan'))

--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -42,7 +42,7 @@ from typing import (
 )
 
 from bumble.colors import color
-from bumble.core import BaseBumbleError, UUID
+from bumble.core import BaseBumbleError, InvalidOperationError, UUID
 from bumble.att import Attribute, AttributeValue
 from bumble.utils import ByteSerializable
 
@@ -679,10 +679,14 @@ class DelegatedCharacteristicAdapter(CharacteristicAdapter):
         self.decode = decode
 
     def encode_value(self, value):
-        return self.encode(value) if self.encode else value
+        if self.encode is None:
+            raise InvalidOperationError('delegated adapter does not have an encoder')
+        return self.encode(value)
 
     def decode_value(self, value):
-        return self.decode(value) if self.decode else value
+        if self.decode is None:
+            raise InvalidOperationError('delegate adapter does not have a decoder')
+        return self.decode(value)
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/profiles/aics.py
+++ b/bumble/profiles/aics.py
@@ -451,54 +451,35 @@ class AICSServiceProxy(ProfileServiceProxy):
     def __init__(self, service_proxy: ServiceProxy) -> None:
         self.service_proxy = service_proxy
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
-                GATT_AUDIO_INPUT_STATE_CHARACTERISTIC
-            )
-        ):
-            raise gatt.InvalidServiceError("Audio Input State Characteristic not found")
         self.audio_input_state = SerializableCharacteristicAdapter(
-            characteristics[0], AudioInputState
+            service_proxy.get_required_characteristic_by_uuid(
+                GATT_AUDIO_INPUT_STATE_CHARACTERISTIC
+            ),
+            AudioInputState,
         )
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
-                GATT_GAIN_SETTINGS_ATTRIBUTE_CHARACTERISTIC
-            )
-        ):
-            raise gatt.InvalidServiceError(
-                "Gain Settings Attribute Characteristic not found"
-            )
         self.gain_settings_properties = SerializableCharacteristicAdapter(
-            characteristics[0], GainSettingsProperties
+            service_proxy.get_required_characteristic_by_uuid(
+                GATT_GAIN_SETTINGS_ATTRIBUTE_CHARACTERISTIC
+            ),
+            GainSettingsProperties,
         )
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
+        self.audio_input_status = PackedCharacteristicAdapter(
+            service_proxy.get_required_characteristic_by_uuid(
                 GATT_AUDIO_INPUT_STATUS_CHARACTERISTIC
-            )
-        ):
-            raise gatt.InvalidServiceError(
-                "Audio Input Status Characteristic not found"
-            )
-        self.audio_input_status = PackedCharacteristicAdapter(characteristics[0], 'B')
+            ),
+            'B',
+        )
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
+        self.audio_input_control_point = (
+            service_proxy.get_required_characteristic_by_uuid(
                 GATT_AUDIO_INPUT_CONTROL_POINT_CHARACTERISTIC
             )
-        ):
-            raise gatt.InvalidServiceError(
-                "Audio Input Control Point Characteristic not found"
-            )
-        self.audio_input_control_point = characteristics[0]
+        )
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
+        self.audio_input_description = UTF8CharacteristicAdapter(
+            service_proxy.get_required_characteristic_by_uuid(
                 GATT_AUDIO_INPUT_DESCRIPTION_CHARACTERISTIC
             )
-        ):
-            raise gatt.InvalidServiceError(
-                "Audio Input Description Characteristic not found"
-            )
-        self.audio_input_description = UTF8CharacteristicAdapter(characteristics[0])
+        )

--- a/bumble/profiles/asha.py
+++ b/bumble/profiles/asha.py
@@ -288,8 +288,8 @@ class AshaServiceProxy(gatt_client.ProfileServiceProxy):
                 'psm_characteristic',
             ),
         ):
-            if not (
-                characteristics := self.service_proxy.get_characteristics_by_uuid(uuid)
-            ):
-                raise gatt.InvalidServiceError(f"Missing {uuid} Characteristic")
-            setattr(self, attribute_name, characteristics[0])
+            setattr(
+                self,
+                attribute_name,
+                self.service_proxy.get_required_characteristic_by_uuid(uuid),
+            )

--- a/bumble/profiles/gmap.py
+++ b/bumble/profiles/gmap.py
@@ -30,7 +30,6 @@ from bumble.gatt import (
     GATT_UGT_FEATURES_CHARACTERISTIC,
     GATT_BGS_FEATURES_CHARACTERISTIC,
     GATT_BGR_FEATURES_CHARACTERISTIC,
-    InvalidServiceError,
 )
 from bumble.gatt_client import ProfileServiceProxy, ServiceProxy
 from enum import IntFlag
@@ -154,14 +153,10 @@ class GamingAudioServiceProxy(ProfileServiceProxy):
     def __init__(self, service_proxy: ServiceProxy) -> None:
         self.service_proxy = service_proxy
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
-                GATT_GMAP_ROLE_CHARACTERISTIC
-            )
-        ):
-            raise InvalidServiceError("GMAP Role Characteristic not found")
         self.gmap_role = DelegatedCharacteristicAdapter(
-            characteristic=characteristics[0],
+            service_proxy.get_required_characteristic_by_uuid(
+                GATT_GMAP_ROLE_CHARACTERISTIC
+            ),
             decode=lambda value: GmapRole(value[0]),
         )
 

--- a/bumble/profiles/le_audio.py
+++ b/bumble/profiles/le_audio.py
@@ -18,22 +18,32 @@
 from __future__ import annotations
 import dataclasses
 import struct
-from typing import List, Type
+from typing import Any, List, Type
 from typing_extensions import Self
 
+from bumble.profiles import bap
 from bumble import utils
 
 
 # -----------------------------------------------------------------------------
 # Classes
 # -----------------------------------------------------------------------------
+class AudioActiveState(utils.OpenIntEnum):
+    NO_AUDIO_DATA_TRANSMITTED = 0x00
+    AUDIO_DATA_TRANSMITTED = 0x01
+
+
+class AssistedListeningStream(utils.OpenIntEnum):
+    UNSPECIFIED_AUDIO_ENHANCEMENT = 0x00
+
+
 @dataclasses.dataclass
 class Metadata:
     '''Bluetooth Assigned Numbers, Section 6.12.6 - Metadata LTV structures.
 
-    As Metadata fields may extend, and Spec doesn't forbid duplication, we don't parse
-    Metadata into a key-value style dataclass here. Rather, we encourage users to parse
-    again outside the lib.
+    As Metadata fields may extend, and Spec doesn't forbid duplication, we don't
+    automatically parse the Metadata data into specific classes. Callers may decode
+    the data by themselves, or use the Entry.decode method.
     '''
 
     class Tag(utils.OpenIntEnum):
@@ -56,6 +66,44 @@ class Metadata:
     class Entry:
         tag: Metadata.Tag
         data: bytes
+
+        def decode(self) -> Any:
+            """
+            Decode the data into an object, if possible.
+
+            If no specific object class exists to represent the data, the raw data
+            bytes are returned.
+            """
+
+            if self.tag in (
+                Metadata.Tag.PREFERRED_AUDIO_CONTEXTS,
+                Metadata.Tag.STREAMING_AUDIO_CONTEXTS,
+            ):
+                return bap.ContextType(struct.unpack("<H", self.data)[0])
+
+            if self.tag in (
+                Metadata.Tag.PROGRAM_INFO,
+                Metadata.Tag.PROGRAM_INFO_URI,
+                Metadata.Tag.BROADCAST_NAME,
+            ):
+                return self.data.decode("utf-8")
+
+            if self.tag == Metadata.Tag.LANGUAGE:
+                return self.data.decode("ascii")
+
+            if self.tag == Metadata.Tag.CCID_LIST:
+                return list(self.data)
+
+            if self.tag == Metadata.Tag.PARENTAL_RATING:
+                return self.data[0]
+
+            if self.tag == Metadata.Tag.AUDIO_ACTIVE_STATE:
+                return AudioActiveState(self.data[0])
+
+            if self.tag == Metadata.Tag.ASSISTED_LISTENING_STREAM:
+                return AssistedListeningStream(self.data[0])
+
+            return self.data
 
         @classmethod
         def from_bytes(cls: Type[Self], data: bytes) -> Self:
@@ -81,3 +129,13 @@ class Metadata:
 
     def __bytes__(self) -> bytes:
         return b''.join([bytes(entry) for entry in self.entries])
+
+    def __str__(self) -> str:
+        entries_str = []
+        for entry in self.entries:
+            decoded = entry.decode()
+            entries_str.append(
+                f'{entry.tag.name}: '
+                f'{decoded.hex() if isinstance(decoded, bytes) else decoded!r}'
+            )
+        return f'Metadata(entries={", ".join(entry_str for entry_str in entries_str)})'

--- a/bumble/profiles/tmap.py
+++ b/bumble/profiles/tmap.py
@@ -25,7 +25,6 @@ from bumble.gatt import (
     TemplateService,
     Characteristic,
     DelegatedCharacteristicAdapter,
-    InvalidServiceError,
     GATT_TELEPHONY_AND_MEDIA_AUDIO_SERVICE,
     GATT_TMAP_ROLE_CHARACTERISTIC,
 )
@@ -74,15 +73,10 @@ class TelephonyAndMediaAudioServiceProxy(ProfileServiceProxy):
     def __init__(self, service_proxy: ServiceProxy):
         self.service_proxy = service_proxy
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
-                GATT_TMAP_ROLE_CHARACTERISTIC
-            )
-        ):
-            raise InvalidServiceError('TMAP Role characteristic not found')
-
         self.role = DelegatedCharacteristicAdapter(
-            characteristics[0],
+            service_proxy.get_required_characteristic_by_uuid(
+                GATT_TMAP_ROLE_CHARACTERISTIC
+            ),
             decode=lambda value: Role(
                 struct.unpack_from('<H', value, 0)[0],
             ),

--- a/bumble/profiles/vocs.py
+++ b/bumble/profiles/vocs.py
@@ -27,8 +27,8 @@ from bumble.gatt import (
     DelegatedCharacteristicAdapter,
     TemplateService,
     CharacteristicValue,
+    SerializableCharacteristicAdapter,
     UTF8CharacteristicAdapter,
-    InvalidServiceError,
     GATT_VOLUME_OFFSET_CONTROL_SERVICE,
     GATT_VOLUME_OFFSET_STATE_CHARACTERISTIC,
     GATT_AUDIO_LOCATION_CHARACTERISTIC,
@@ -287,44 +287,28 @@ class VolumeOffsetControlServiceProxy(ProfileServiceProxy):
     def __init__(self, service_proxy: ServiceProxy) -> None:
         self.service_proxy = service_proxy
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
-                GATT_VOLUME_OFFSET_STATE_CHARACTERISTIC
-            )
-        ):
-            raise InvalidServiceError("Volume Offset State characteristic not found")
         self.volume_offset_state = DelegatedCharacteristicAdapter(
-            characteristics[0], decode=VolumeOffsetState.from_bytes
+            service_proxy.get_required_characteristic_by_uuid(
+                GATT_VOLUME_OFFSET_STATE_CHARACTERISTIC
+            ),
+            decode=VolumeOffsetState.from_bytes,
         )
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
+        self.audio_location = SerializableCharacteristicAdapter(
+            service_proxy.get_required_characteristic_by_uuid(
                 GATT_AUDIO_LOCATION_CHARACTERISTIC
-            )
-        ):
-            raise InvalidServiceError("Audio Location characteristic not found")
-        self.audio_location = DelegatedCharacteristicAdapter(
-            characteristics[0],
-            encode=lambda value: bytes(value),
-            decode=VocsAudioLocation.from_bytes,
+            ),
+            VocsAudioLocation,
         )
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
+        self.volume_offset_control_point = (
+            service_proxy.get_required_characteristic_by_uuid(
                 GATT_VOLUME_OFFSET_CONTROL_POINT_CHARACTERISTIC
             )
-        ):
-            raise InvalidServiceError(
-                "Volume Offset Control Point characteristic not found"
-            )
-        self.volume_offset_control_point = characteristics[0]
+        )
 
-        if not (
-            characteristics := service_proxy.get_characteristics_by_uuid(
+        self.audio_output_description = UTF8CharacteristicAdapter(
+            service_proxy.get_required_characteristic_by_uuid(
                 GATT_AUDIO_OUTPUT_DESCRIPTION_CHARACTERISTIC
             )
-        ):
-            raise InvalidServiceError(
-                "Audio Output Description characteristic not found"
-            )
-        self.audio_output_description = UTF8CharacteristicAdapter(characteristics[0])
+        )

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -39,12 +39,14 @@ nav:
   - Drivers:
     - drivers/index.md
     - Realtek: drivers/realtek.md
+    - Intel: drivers/intel.md
   - API:
     - Guide: api/guide.md
     - Examples: api/examples.md
     - Reference: api/reference.md
   - Apps & Tools:
     - apps_and_tools/index.md
+    - Auracast: apps_and_tools/auracast.md
     - Console: apps_and_tools/console.md
     - Bench: apps_and_tools/bench.md
     - Speaker: apps_and_tools/speaker.md
@@ -108,8 +110,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.tabbed:
       alternate_style: true
   - codehilite:

--- a/docs/mkdocs/src/apps_and_tools/index.md
+++ b/docs/mkdocs/src/apps_and_tools/index.md
@@ -4,12 +4,13 @@ APPS & TOOLS
 Included in the project are a few apps and tools, built on top of the core libraries.
 These include:
 
-  * [Console](console.md) - an interactive text-based console
-  * [Bench](bench.md) - Speed and Latency benchmarking between two devices (LE and Classic)
-  * [Pair](pair.md) - Pair/bond two devices (LE and Classic)
-  * [Unbond](unbond.md) - Remove a previously established bond
-  * [HCI Bridge](hci_bridge.md) - a HCI transport bridge to connect two HCI transports and filter/snoop the HCI packets
-  * [Golden Gate Bridge](gg_bridge.md) - a bridge between GATT and UDP to use with the Golden Gate "stack tool"
-  * [Show](show.md) - Parse a file with HCI packets and print the details of each packet in a human readable form
+  * [Auracast](auracast.md) - Commands to broadcast, receive and/or control LE Audio.
+  * [Console](console.md) - An interactive text-based console.
+  * [Bench](bench.md) - Speed and Latency benchmarking between two devices (LE and Classic).
+  * [Pair](pair.md) - Pair/bond two devices (LE and Classic).
+  * [Unbond](unbond.md) - Remove a previously established bond.
+  * [HCI Bridge](hci_bridge.md) - An HCI transport bridge to connect two HCI transports and filter/snoop the HCI packets.
+  * [Golden Gate Bridge](gg_bridge.md) - Bridge between GATT and UDP to use with the Golden Gate "stack tool".
+  * [Show](show.md) - Parse a file with HCI packets and print the details of each packet in a human readable form.
   * [Speaker](speaker.md) - Virtual Bluetooth speaker, with a command line and browser-based UI.
   * [Link Relay](link_relay.md) - WebSocket relay for virtual RemoteLink instances to communicate with each other.

--- a/docs/mkdocs/src/getting_started.md
+++ b/docs/mkdocs/src/getting_started.md
@@ -9,9 +9,9 @@ for your platform.
 Throughout the documentation, when shell commands are shown, it is assumed that you can
 invoke Python as
 ```
-$ python
+$ python3
 ```
-If invoking python is different on your platform (it may be `python3` for example, or just `py` or `py.exe`),
+If invoking python is different on your platform (it may be `python` for example, or just `py` or `py.exe`),
 adjust accordingly.
 
 You may be simply using Bumble as a module for your own application or as a dependency to your own
@@ -30,12 +30,18 @@ manager, or from source.
     python environment, or in a virtual environment, such as a `venv`, `pyenv` or `conda` environment.
     See the [Python Environments page](development/python_environments.md) page for details.
 
+### Install from PyPI
+
+```
+$ python3 -m pip install bumble
+```
+
 ### Install From Source
 
 Install with `pip`. Run in a command shell in the directory where you downloaded the source
 distribution
 ```
-$ python -m pip install -e .
+$ python3 -m pip install -e .
 ```
 
 ### Install from GitHub
@@ -44,21 +50,21 @@ You can install directly from GitHub without first downloading the repo.
 
 Install the latest commit from the main branch with `pip`:
 ```
-$ python -m pip install git+https://github.com/google/bumble.git
+$ python3 -m pip install git+https://github.com/google/bumble.git
 ```
 
 You can specify a specific tag.
 
 Install tag `v0.0.1` with `pip`:
 ```
-$ python -m pip install git+https://github.com/google/bumble.git@v0.0.1
+$ python3 -m pip install git+https://github.com/google/bumble.git@v0.0.1
 ```
 
 You can also specify a specific commit.
 
 Install commit `27c0551` with `pip`:
 ```
-$ python -m pip install git+https://github.com/google/bumble.git@27c0551
+$ python3 -m pip install git+https://github.com/google/bumble.git@27c0551
 ```
 
 # Working On The Bumble Code
@@ -78,21 +84,21 @@ directory of the project.
 
 ```bash
 $ export PYTHONPATH=.
-$ python apps/console.py serial:/dev/tty.usbmodem0006839912171
+$ python3 apps/console.py serial:/dev/tty.usbmodem0006839912171
 ```
 
 or running an example, with the working directory set to the `examples` subdirectory
 ```bash
 $ cd examples
 $ export PYTHONPATH=..
-$ python run_scanner.py usb:0
+$ python3 run_scanner.py usb:0
 ```
 
 Or course, `export PYTHONPATH` only needs to be invoked once, not before each app/script execution.
 
 Setting `PYTHONPATH` locally with each command would look something like:
 ```
-$ PYTHONPATH=. python examples/run_advertiser.py examples/device1.json serial:/dev/tty.usbmodem0006839912171
+$ PYTHONPATH=. python3 examples/run_advertiser.py examples/device1.json serial:/dev/tty.usbmodem0006839912171
 ```
 
 # Where To Go Next

--- a/docs/mkdocs/src/platforms/android.md
+++ b/docs/mkdocs/src/platforms/android.md
@@ -35,11 +35,11 @@ the command line.
     visit [this Android Studio user guide page](https://developer.android.com/studio/run/emulator-commandline)
 
 The `-packet-streamer-endpoint <endpoint>` command line option may be used to enable
-Bluetooth emulation and tell the emulator which virtual controller to connect to. 
+Bluetooth emulation and tell the emulator which virtual controller to connect to.
 
 ## Connecting to Netsim
 
-If the emulator doesn't have Bluetooth emulation enabled by default, use the 
+If the emulator doesn't have Bluetooth emulation enabled by default, use the
 `-packet-streamer-endpoint default` option to tell it to connect to Netsim.
 If Netsim is not running, the emulator will start it automatically.
 
@@ -60,17 +60,17 @@ the Bumble `android-netsim` transport in `host` mode (the default).
 
 !!! example "Run the example GATT server connected to the emulator via Netsim"
     ``` shell
-    $ python run_gatt_server.py device1.json android-netsim
+    $ python3 run_gatt_server.py device1.json android-netsim
     ```
 
 By default, the Bumble `android-netsim` transport will try to automatically discover
 the port number on which the netsim process is exposing its gRPC server interface. If
-that discovery process fails, or if you want to specify the interface manually, you 
+that discovery process fails, or if you want to specify the interface manually, you
 can pass a `hostname` and `port` as parameters to the transport, as: `android-netsim:<host>:<port>`.
 
 !!! example "Run the example GATT server connected to the emulator via Netsim on a localhost, port 8877"
     ``` shell
-    $ python run_gatt_server.py device1.json android-netsim:localhost:8877
+    $ python3 run_gatt_server.py device1.json android-netsim:localhost:8877
     ```
 
 ### Multiple Instances
@@ -84,7 +84,7 @@ For example: `android-netsim:localhost:8877,name=bumble1`
 This is an advanced use case, which may not be officially supported, but should work in recent
 versions of the emulator.
 
-The first step is to run the Bumble HCI bridge, specifying netsim as the "host" end of the 
+The first step is to run the Bumble HCI bridge, specifying netsim as the "host" end of the
 bridge, and another controller (typically a USB Bluetooth dongle, but any other supported
 transport can work as well) as the "controller" end of the bridge.
 

--- a/examples/run_gatt_with_adapters.py
+++ b/examples/run_gatt_with_adapters.py
@@ -25,7 +25,7 @@ import struct
 import sys
 from typing import Any, List, Union
 
-from bumble.device import Connection, Device, Peer
+from bumble.device import Device, Peer
 from bumble import transport
 from bumble import gatt
 from bumble import hci
@@ -82,19 +82,19 @@ async def client(device: Device, address: hci.Address) -> None:
     for index in range(1, 9):
         characteristics.append(
             service.get_characteristics_by_uuid(
-                CHARACTERISTIC_UUID_BASE + f"{index:02X}"
+                core.UUID(CHARACTERISTIC_UUID_BASE + f"{index:02X}")
             )[0]
         )
 
     # Read all characteristics as raw bytes.
     for characteristic in characteristics:
         value = await characteristic.read_value()
-        print(f"### {characteristic} = {value} ({value.hex()})")
+        print(f"### {characteristic} = {value!r} ({value.hex()})")
 
     # Static characteristic with a bytes value.
     c1 = characteristics[0]
     c1_value = await c1.read_value()
-    print(f"@@@ C1 {c1} value = {c1_value} (type={type(c1_value)})")
+    print(f"@@@ C1 {c1} value = {c1_value!r} (type={type(c1_value)})")
     await c1.write_value("happy π day".encode("utf-8"))
 
     # Static characteristic with a string value.
@@ -136,7 +136,7 @@ async def client(device: Device, address: hci.Address) -> None:
     # Dynamic characteristic with a bytes value.
     c7 = characteristics[6]
     c7_value = await c7.read_value()
-    print(f"@@@ C7 {c7} value = {c7_value} (type={type(c7_value)})")
+    print(f"@@@ C7 {c7} value = {c7_value!r} (type={type(c7_value)})")
     await c7.write_value(bytes.fromhex("01020304"))
 
     # Dynamic characteristic with a string value.

--- a/examples/run_vcp_renderer.py
+++ b/examples/run_vcp_renderer.py
@@ -174,16 +174,10 @@ async def main() -> None:
             ws = websocket
             async for message in websocket:
                 volume_state = json.loads(message)
-                vcs.volume_state_bytes = bytes(
-                    [
-                        volume_state['volume_setting'],
-                        volume_state['muted'],
-                        volume_state['change_counter'],
-                    ]
-                )
-                await device.notify_subscribers(
-                    vcs.volume_state, vcs.volume_state_bytes
-                )
+                vcs.volume_setting = volume_state['volume_setting']
+                vcs.muted = volume_state['muted']
+                vcs.change_counter = volume_state['change_counter']
+                await device.notify_subscribers(vcs.volume_state)
             ws = None
 
         await websockets.serve(serve, 'localhost', 8989)

--- a/examples/run_vcp_renderer.py
+++ b/examples/run_vcp_renderer.py
@@ -42,7 +42,7 @@ from bumble.profiles.bap import (
 from bumble.profiles.pacs import PacRecord, PublishedAudioCapabilitiesService
 from bumble.profiles.cap import CommonAudioServiceService
 from bumble.profiles.csip import CoordinatedSetIdentificationService, SirkType
-from bumble.profiles.vcp import VolumeControlService
+from bumble.profiles.vcs import VolumeControlService
 
 from bumble.transport import open_transport_or_link
 
@@ -117,13 +117,17 @@ async def main() -> None:
 
         ws: Optional[websockets.WebSocketServerProtocol] = None
 
-        def on_volume_state(volume_setting: int, muted: int, change_counter: int):
+        def on_volume_state_change():
             if ws:
                 asyncio.create_task(
-                    ws.send(dumps_volume_state(volume_setting, muted, change_counter))
+                    ws.send(
+                        dumps_volume_state(
+                            vcs.volume_setting, vcs.muted, vcs.change_counter
+                        )
+                    )
                 )
 
-        vcs.on('volume_state', on_volume_state)
+        vcs.on('volume_state_change', on_volume_state_change)
 
         advertising_data = (
             bytes(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,16 +61,17 @@ avatar = [
 ]
 pandora = ["bt-test-interfaces >= 0.0.6"]
 documentation = [
-    "mkdocs >= 1.4.0",
-    "mkdocs-material >= 8.5.6",
-    "mkdocstrings[python] >= 0.19.0",
+    "mkdocs >= 1.6.0",
+    "mkdocs-material >= 9.6",
+    "mkdocstrings[python] >= 0.27.0",
 ]
 auracast = [
-    "lc3 @ git+https://github.com/google/liblc3.git",
+    "lc3py ; python_version>='3.10' and platform_system=='Linux' and platform_machine=='x86_64'",
     "sounddevice >= 0.5.1",
 ]
 
 [project.scripts]
+bumble-auracast = "bumble.apps.auracast:main"
 bumble-ble-rpa-tool = "bumble.apps.ble_rpa_tool:main"
 bumble-console = "bumble.apps.console:main"
 bumble-controller-info = "bumble.apps.controller_info:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,9 @@ documentation = [
     "mkdocs-material >= 8.5.6",
     "mkdocstrings[python] >= 0.19.0",
 ]
-lc3 = [
+auracast = [
     "lc3 @ git+https://github.com/google/liblc3.git",
+    "sounddevice >= 0.5.1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,10 @@ module = "serial_asyncio.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "sounddevice.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "usb.*"
 ignore_missing_imports = true
 

--- a/tests/aics_test.py
+++ b/tests/aics_test.py
@@ -33,7 +33,7 @@ from bumble.profiles.aics import (
     AudioInputControlPointOpCode,
     ErrorCode,
 )
-from bumble.profiles.vcp import VolumeControlService, VolumeControlServiceProxy
+from bumble.profiles.vcs import VolumeControlService, VolumeControlServiceProxy
 
 from .test_utils import TwoDevices
 

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -53,7 +53,7 @@ def test_import():
         le_audio,
         pacs,
         pbp,
-        vcp,
+        vcs,
     )
 
     assert att
@@ -87,7 +87,7 @@ def test_import():
     assert le_audio
     assert pacs
     assert pbp
-    assert vcp
+    assert vcs
 
 
 # -----------------------------------------------------------------------------

--- a/tests/vcp_test.py
+++ b/tests/vcp_test.py
@@ -20,7 +20,7 @@ import pytest_asyncio
 import logging
 
 from bumble import device
-from bumble.profiles import vcp
+from bumble.profiles import vcs
 from .test_utils import TwoDevices
 
 # -----------------------------------------------------------------------------
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 async def vcp_client():
     devices = TwoDevices()
     devices[0].add_service(
-        vcp.VolumeControlService(volume_setting=32, muted=1, volume_flags=1)
+        vcs.VolumeControlService(volume_setting=32, muted=1, volume_flags=1)
     )
 
     await devices.setup_connection()
@@ -48,76 +48,76 @@ async def vcp_client():
 
     peer = device.Peer(devices.connections[1])
     vcp_client = await peer.discover_service_and_create_proxy(
-        vcp.VolumeControlServiceProxy
+        vcs.VolumeControlServiceProxy
     )
     yield vcp_client
 
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_init_service(vcp_client: vcp.VolumeControlServiceProxy):
+async def test_init_service(vcp_client: vcs.VolumeControlServiceProxy):
     assert (await vcp_client.volume_flags.read_value()) == 1
-    assert (await vcp_client.volume_state.read_value()) == (32, 1, 0)
+    assert (await vcp_client.volume_state.read_value()) == vcs.VolumeState(32, 1, 0)
 
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_relative_volume_down(vcp_client: vcp.VolumeControlServiceProxy):
+async def test_relative_volume_down(vcp_client: vcs.VolumeControlServiceProxy):
     await vcp_client.volume_control_point.write_value(
-        bytes([vcp.VolumeControlPointOpcode.RELATIVE_VOLUME_DOWN, 0])
+        bytes([vcs.VolumeControlPointOpcode.RELATIVE_VOLUME_DOWN, 0])
     )
-    assert (await vcp_client.volume_state.read_value()) == (16, 1, 1)
+    assert (await vcp_client.volume_state.read_value()) == vcs.VolumeState(16, 1, 1)
 
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_relative_volume_up(vcp_client: vcp.VolumeControlServiceProxy):
+async def test_relative_volume_up(vcp_client: vcs.VolumeControlServiceProxy):
     await vcp_client.volume_control_point.write_value(
-        bytes([vcp.VolumeControlPointOpcode.RELATIVE_VOLUME_UP, 0])
+        bytes([vcs.VolumeControlPointOpcode.RELATIVE_VOLUME_UP, 0])
     )
-    assert (await vcp_client.volume_state.read_value()) == (48, 1, 1)
+    assert (await vcp_client.volume_state.read_value()) == vcs.VolumeState(48, 1, 1)
 
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_unmute_relative_volume_down(vcp_client: vcp.VolumeControlServiceProxy):
+async def test_unmute_relative_volume_down(vcp_client: vcs.VolumeControlServiceProxy):
     await vcp_client.volume_control_point.write_value(
-        bytes([vcp.VolumeControlPointOpcode.UNMUTE_RELATIVE_VOLUME_DOWN, 0])
+        bytes([vcs.VolumeControlPointOpcode.UNMUTE_RELATIVE_VOLUME_DOWN, 0])
     )
-    assert (await vcp_client.volume_state.read_value()) == (16, 0, 1)
+    assert (await vcp_client.volume_state.read_value()) == vcs.VolumeState(16, 0, 1)
 
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_unmute_relative_volume_up(vcp_client: vcp.VolumeControlServiceProxy):
+async def test_unmute_relative_volume_up(vcp_client: vcs.VolumeControlServiceProxy):
     await vcp_client.volume_control_point.write_value(
-        bytes([vcp.VolumeControlPointOpcode.UNMUTE_RELATIVE_VOLUME_UP, 0])
+        bytes([vcs.VolumeControlPointOpcode.UNMUTE_RELATIVE_VOLUME_UP, 0])
     )
-    assert (await vcp_client.volume_state.read_value()) == (48, 0, 1)
+    assert (await vcp_client.volume_state.read_value()) == vcs.VolumeState(48, 0, 1)
 
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_set_absolute_volume(vcp_client: vcp.VolumeControlServiceProxy):
+async def test_set_absolute_volume(vcp_client: vcs.VolumeControlServiceProxy):
     await vcp_client.volume_control_point.write_value(
-        bytes([vcp.VolumeControlPointOpcode.SET_ABSOLUTE_VOLUME, 0, 255])
+        bytes([vcs.VolumeControlPointOpcode.SET_ABSOLUTE_VOLUME, 0, 255])
     )
-    assert (await vcp_client.volume_state.read_value()) == (255, 1, 1)
+    assert (await vcp_client.volume_state.read_value()) == vcs.VolumeState(255, 1, 1)
 
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_mute(vcp_client: vcp.VolumeControlServiceProxy):
+async def test_mute(vcp_client: vcs.VolumeControlServiceProxy):
     await vcp_client.volume_control_point.write_value(
-        bytes([vcp.VolumeControlPointOpcode.MUTE, 0])
+        bytes([vcs.VolumeControlPointOpcode.MUTE, 0])
     )
-    assert (await vcp_client.volume_state.read_value()) == (32, 1, 0)
+    assert (await vcp_client.volume_state.read_value()) == vcs.VolumeState(32, 1, 0)
 
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_unmute(vcp_client: vcp.VolumeControlServiceProxy):
+async def test_unmute(vcp_client: vcs.VolumeControlServiceProxy):
     await vcp_client.volume_control_point.write_value(
-        bytes([vcp.VolumeControlPointOpcode.UNMUTE, 0])
+        bytes([vcs.VolumeControlPointOpcode.UNMUTE, 0])
     )
-    assert (await vcp_client.volume_state.read_value()) == (32, 0, 1)
+    assert (await vcp_client.volume_state.read_value()) == vcs.VolumeState(32, 0, 1)

--- a/tests/vocs_test.py
+++ b/tests/vocs_test.py
@@ -32,7 +32,6 @@ from bumble.profiles.vocs import (
     SetVolumeOffsetOpCode,
     VolumeOffsetControlServiceProxy,
     VolumeOffsetState,
-    VocsAudioLocation,
 )
 from bumble.profiles.vcs import VolumeControlService, VolumeControlServiceProxy
 from bumble.profiles.bap import AudioLocation
@@ -81,9 +80,7 @@ async def test_init_service(vocs_client: VolumeOffsetControlServiceProxy):
         volume_offset=0,
         change_counter=0,
     )
-    assert await vocs_client.audio_location.read_value() == VocsAudioLocation(
-        audio_location=AudioLocation.NOT_ALLOWED
-    )
+    assert await vocs_client.audio_location.read_value() == AudioLocation.NOT_ALLOWED
     description = await vocs_client.audio_output_description.read_value()
     assert description == ''
 
@@ -162,11 +159,9 @@ async def test_set_volume_offset(vocs_client: VolumeOffsetControlServiceProxy):
 
 @pytest.mark.asyncio
 async def test_set_audio_channel_location(vocs_client: VolumeOffsetControlServiceProxy):
-    new_audio_location = VocsAudioLocation(audio_location=AudioLocation.FRONT_LEFT)
+    new_audio_location = AudioLocation.FRONT_LEFT
 
-    await vocs_client.audio_location.write_value(
-        struct.pack('<I', new_audio_location.audio_location)
-    )
+    await vocs_client.audio_location.write_value(new_audio_location)
 
     location = await vocs_client.audio_location.read_value()
     assert location == new_audio_location

--- a/tests/vocs_test.py
+++ b/tests/vocs_test.py
@@ -34,7 +34,7 @@ from bumble.profiles.vocs import (
     VolumeOffsetState,
     VocsAudioLocation,
 )
-from bumble.profiles.vcp import VolumeControlService, VolumeControlServiceProxy
+from bumble.profiles.vcs import VolumeControlService, VolumeControlServiceProxy
 from bumble.profiles.bap import AudioLocation
 
 from .test_utils import TwoDevices


### PR DESCRIPTION
This allows the auracast app to use the host's sound devices for input and output, in addition to other input and output types (file, stdio, external process).
The dependency on lc3 has changed, because PyPI does not allow `git` external dependencies.
Also included are small changes to some of the LE Audio GATT services, to use object types instead of raw bytes or tuples where appropriate (there are still maybe a few characteristics left to 'objectify', which can be done in subsequent PRs).
A later PR will include improvements to the typing support for GATT adapters.