### PR TITLE
Add setup_data_path for iso queues

### DIFF
--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -965,6 +965,11 @@ async def run_transmit(
                 bumble.device.IsoPacketStream(big.bis_links[1], 64),
             ]
 
+            for queue in iso_queues:
+                await queue.iso_link.setup_data_path(
+                    direction=queue.iso_link.Direction.HOST_TO_CONTROLLER
+            )
+
             def on_flow():
                 data_packet_queue = iso_queues[0].data_packet_queue
                 print(

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -692,7 +692,7 @@ async def run_receive(
         def on_new_broadcast(broadcast: BroadcastScanner.Broadcast) -> None:
             if scan_result.done():
                 return
-            if broadcast_id is None or broadcast.broadcast_:id == broadcast_id:
+            if broadcast_id is None or broadcast.broadcast_id == broadcast_id:
                 scan_result.set_result(broadcast)
 
         scanner.on('new_broadcast', on_new_broadcast)

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -962,7 +962,7 @@ async def run_transmit(
             for bis_link in big.bis_links:
                 await bis_link.setup_data_path(
                     direction=bis_link.Direction.HOST_TO_CONTROLLER
-            )
+                )
 
             iso_queues = [
                 bumble.device.IsoPacketStream(big.bis_links[0], 64),

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -965,9 +965,9 @@ async def run_transmit(
                 bumble.device.IsoPacketStream(big.bis_links[1], 64),
             ]
 
-            for queue in iso_queues:
-                await queue.iso_link.setup_data_path(
-                    direction=queue.iso_link.Direction.HOST_TO_CONTROLLER
+            for bis_link in big.bis_links:
+                await bis_link.setup_data_path(
+                    direction=bis_link.Direction.HOST_TO_CONTROLLER
             )
 
             def on_flow():

--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -692,7 +692,7 @@ async def run_receive(
         def on_new_broadcast(broadcast: BroadcastScanner.Broadcast) -> None:
             if scan_result.done():
                 return
-            if broadcast_id is None or broadcast.broadcast_id == broadcast_id:
+            if broadcast_id is None or broadcast.broadcast_:id == broadcast_id:
                 scan_result.set_result(broadcast)
 
         scanner.on('new_broadcast', on_new_broadcast)
@@ -959,16 +959,15 @@ async def run_transmit(
                     ),
                 ),
             )
+            for bis_link in big.bis_links:
+                await bis_link.setup_data_path(
+                    direction=bis_link.Direction.HOST_TO_CONTROLLER
+            )
 
             iso_queues = [
                 bumble.device.IsoPacketStream(big.bis_links[0], 64),
                 bumble.device.IsoPacketStream(big.bis_links[1], 64),
             ]
-
-            for bis_link in big.bis_links:
-                await bis_link.setup_data_path(
-                    direction=bis_link.Direction.HOST_TO_CONTROLLER
-            )
 
             def on_flow():
                 data_packet_queue = iso_queues[0].data_packet_queue


### PR DESCRIPTION
The auracast app only starts work again if we call setup_data_path after instantiating the IsoPacketStream object.

Before this change, the Number of completed packages event from controller to host always returns a zero handle like so:
```
< ISO Data TX: Handle 39 flags 0x02 dlen 104                                                                                                                                      #97 284.682500
> HCI Event: Number of Completed Packets (0x13) plen 5                                                                                                                            #98 284.682700
        Num handles: 1
        Handle: 0
        Count: 1
```
After this change, The broadcast is sent without any errors and can also be received with a pair of earbuds.

The setup that was used two test is with transport serial.
Tested with:
1. nrf54l15-dk with hci_uart firmware 
2. nrf52dongle with hci_uart over usb cdc
