### PR TITLE
make connection phy async

### DIFF
--- a/apps/bench.py
+++ b/apps/bench.py
@@ -104,15 +104,16 @@ def le_phy_name(phy_id):
     )
 
 
+def print_connection_phy(phy):
+    logging.info(
+        color('@@@ PHY: ', 'yellow') + f'TX:{le_phy_name(phy.tx_phy)}/'
+        f'RX:{le_phy_name(phy.rx_phy)}'
+    )
+
+
 def print_connection(connection):
     params = []
     if connection.transport == BT_LE_TRANSPORT:
-        params.append(
-            'PHY='
-            f'TX:{le_phy_name(connection.phy.tx_phy)}/'
-            f'RX:{le_phy_name(connection.phy.rx_phy)}'
-        )
-
         params.append(
             'DL=('
             f'TX:{connection.data_length[0]}/{connection.data_length[1]},'
@@ -1288,6 +1289,8 @@ class Central(Connection.Listener):
             logging.info(color('### Connected', 'cyan'))
             self.connection.listener = self
             print_connection(self.connection)
+            phy = await self.connection.get_phy()
+            print_connection_phy(phy)
 
             # Switch roles if needed.
             if self.role_switch:
@@ -1345,8 +1348,8 @@ class Central(Connection.Listener):
     def on_connection_parameters_update(self):
         print_connection(self.connection)
 
-    def on_connection_phy_update(self):
-        print_connection(self.connection)
+    def on_connection_phy_update(self, phy):
+        print_connection_phy(phy)
 
     def on_connection_att_mtu_update(self):
         print_connection(self.connection)
@@ -1472,8 +1475,8 @@ class Peripheral(Device.Listener, Connection.Listener):
     def on_connection_parameters_update(self):
         print_connection(self.connection)
 
-    def on_connection_phy_update(self):
-        print_connection(self.connection)
+    def on_connection_phy_update(self, phy):
+        print_connection_phy(phy)
 
     def on_connection_att_mtu_update(self):
         print_connection(self.connection)

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -1098,8 +1098,11 @@ class Host(AbortableEventEmitter):
 
         # Notify the client
         if event.status == hci.HCI_SUCCESS:
-            connection_phy = ConnectionPHY(event.tx_phy, event.rx_phy)
-            self.emit('connection_phy_update', connection.handle, connection_phy)
+            self.emit(
+                'connection_phy_update',
+                connection.handle,
+                ConnectionPHY(event.tx_phy, event.rx_phy),
+            )
         else:
             self.emit('connection_phy_update_failure', connection.handle, event.status)
 


### PR DESCRIPTION
As reported in #647 it isn't safe to delay the emission of the `connection` even until we have asynchronously read the connection PHY from the controller. Unfortunately, the controller doesn't provide the PHY information when a connection is made, it has to be requested with a command, which is an asynchronous sequence, and thus some data could be received between the time the PHY request is made and the response is received, in which case that data will arrive before the connection event is emitted.
The only clean solution here is that the `Connection` object can't have a synchronous `phy` property. It must be an async "property" (not really a property, because real properties can't be async, but an `async def get_phy()` method).
Also, as a consequence of this change, the `connection_phy_update` event must pass the PHY value as a parameter, so as not to required an un-necessary `get_phy` request from the listener to obtain the information.
This does change the API slightly, but it probably won't break too many users.