### PR TITLE
new GATT adapter classes with proper typing support

### DIFF
--- a/apps/auracast.py
+++ b/apps/auracast.py
@@ -522,14 +522,19 @@ async def run_assist(
             return
 
         # Subscribe to and read the broadcast receive state characteristics
+        def on_broadcast_receive_state_update(
+            value: bass.BroadcastReceiveState, index: int
+        ) -> None:
+            print(
+                f"{color(f'Broadcast Receive State Update [{index}]:', 'green')} {value}"
+            )
+
         for i, broadcast_receive_state in enumerate(
             bass_client.broadcast_receive_states
         ):
             try:
                 await broadcast_receive_state.subscribe(
-                    lambda value, i=i: print(
-                        f"{color(f'Broadcast Receive State Update [{i}]:', 'green')} {value}"
-                    )
+                    functools.partial(on_broadcast_receive_state_update, index=i)
                 )
             except core.ProtocolError as error:
                 print(

--- a/apps/gg_bridge.py
+++ b/apps/gg_bridge.py
@@ -234,7 +234,7 @@ class GattlinkNodeBridge(GattlinkL2capEndpoint, Device.Listener):
             Characteristic.WRITEABLE,
             CharacteristicValue(write=self.on_rx_write),
         )
-        self.tx_characteristic = Characteristic(
+        self.tx_characteristic: Characteristic[bytes] = Characteristic(
             GG_GATTLINK_TX_CHARACTERISTIC_UUID,
             Characteristic.Properties.NOTIFY,
             Characteristic.READABLE,

--- a/bumble/att.py
+++ b/bumble/att.py
@@ -29,13 +29,14 @@ import functools
 import inspect
 import struct
 from typing import (
-    Any,
     Awaitable,
     Callable,
+    Generic,
     Dict,
     List,
     Optional,
     Type,
+    TypeVar,
     Union,
     TYPE_CHECKING,
 )
@@ -43,12 +44,17 @@ from typing import (
 from pyee import EventEmitter
 
 from bumble import utils
-from bumble.core import UUID, name_or_number, ProtocolError
+from bumble.core import UUID, name_or_number, InvalidOperationError, ProtocolError
 from bumble.hci import HCI_Object, key_with_value
 from bumble.colors import color
 
+# -----------------------------------------------------------------------------
+# Typing
+# -----------------------------------------------------------------------------
 if TYPE_CHECKING:
     from bumble.device import Connection
+
+_T = TypeVar('_T')
 
 # -----------------------------------------------------------------------------
 # Constants
@@ -748,7 +754,7 @@ class ATT_Handle_Value_Confirmation(ATT_PDU):
 
 
 # -----------------------------------------------------------------------------
-class AttributeValue:
+class AttributeValue(Generic[_T]):
     '''
     Attribute value where reading and/or writing is delegated to functions
     passed as arguments to the constructor.
@@ -757,33 +763,34 @@ class AttributeValue:
     def __init__(
         self,
         read: Union[
-            Callable[[Optional[Connection]], Any],
-            Callable[[Optional[Connection]], Awaitable[Any]],
+            Callable[[Optional[Connection]], _T],
+            Callable[[Optional[Connection]], Awaitable[_T]],
             None,
         ] = None,
         write: Union[
-            Callable[[Optional[Connection], Any], None],
-            Callable[[Optional[Connection], Any], Awaitable[None]],
+            Callable[[Optional[Connection], _T], None],
+            Callable[[Optional[Connection], _T], Awaitable[None]],
             None,
         ] = None,
     ):
         self._read = read
         self._write = write
 
-    def read(self, connection: Optional[Connection]) -> Union[bytes, Awaitable[bytes]]:
-        return self._read(connection) if self._read else b''
+    def read(self, connection: Optional[Connection]) -> Union[_T, Awaitable[_T]]:
+        if self._read is None:
+            raise InvalidOperationError('AttributeValue has no read function')
+        return self._read(connection)
 
     def write(
-        self, connection: Optional[Connection], value: bytes
+        self, connection: Optional[Connection], value: _T
     ) -> Union[Awaitable[None], None]:
-        if self._write:
-            return self._write(connection, value)
-
-        return None
+        if self._write is None:
+            raise InvalidOperationError('AttributeValue has no write function')
+        return self._write(connection, value)
 
 
 # -----------------------------------------------------------------------------
-class Attribute(EventEmitter):
+class Attribute(EventEmitter, Generic[_T]):
     class Permissions(enum.IntFlag):
         READABLE = 0x01
         WRITEABLE = 0x02
@@ -822,13 +829,13 @@ class Attribute(EventEmitter):
     READ_REQUIRES_AUTHORIZATION = Permissions.READ_REQUIRES_AUTHORIZATION
     WRITE_REQUIRES_AUTHORIZATION = Permissions.WRITE_REQUIRES_AUTHORIZATION
 
-    value: Any
+    value: Union[AttributeValue[_T], _T, None]
 
     def __init__(
         self,
         attribute_type: Union[str, bytes, UUID],
         permissions: Union[str, Attribute.Permissions],
-        value: Any = b'',
+        value: Union[AttributeValue[_T], _T, None] = None,
     ) -> None:
         EventEmitter.__init__(self)
         self.handle = 0
@@ -848,11 +855,11 @@ class Attribute(EventEmitter):
 
         self.value = value
 
-    def encode_value(self, value: Any) -> bytes:
-        return value
+    def encode_value(self, value: _T) -> bytes:
+        return value  # type: ignore
 
-    def decode_value(self, value_bytes: bytes) -> Any:
-        return value_bytes
+    def decode_value(self, value: bytes) -> _T:
+        return value  # type: ignore
 
     async def read_value(self, connection: Optional[Connection]) -> bytes:
         if (
@@ -877,11 +884,16 @@ class Attribute(EventEmitter):
                 error_code=ATT_INSUFFICIENT_AUTHORIZATION_ERROR, att_handle=self.handle
             )
 
-        if hasattr(self.value, 'read'):
+        value: Union[_T, None]
+        if self.value is None:
+            value = None
+        elif hasattr(self.value, 'read'):
             try:
-                value = self.value.read(connection)
-                if inspect.isawaitable(value):
-                    value = await value
+                read_value = self.value.read(connection)
+                if inspect.isawaitable(read_value):
+                    value = await read_value
+                else:
+                    value = read_value
             except ATT_Error as error:
                 raise ATT_Error(
                     error_code=error.error_code, att_handle=self.handle
@@ -889,20 +901,24 @@ class Attribute(EventEmitter):
         else:
             value = self.value
 
-        self.emit('read', connection, value)
+        self.emit('read', connection, b'' if value is None else value)
 
-        return self.encode_value(value)
+        return b'' if value is None else self.encode_value(value)
 
-    async def write_value(self, connection: Connection, value_bytes: bytes) -> None:
+    async def write_value(self, connection: Optional[Connection], value: bytes) -> None:
         if (
-            self.permissions & self.WRITE_REQUIRES_ENCRYPTION
-        ) and not connection.encryption:
+            (self.permissions & self.WRITE_REQUIRES_ENCRYPTION)
+            and connection is not None
+            and not connection.encryption
+        ):
             raise ATT_Error(
                 error_code=ATT_INSUFFICIENT_ENCRYPTION_ERROR, att_handle=self.handle
             )
         if (
-            self.permissions & self.WRITE_REQUIRES_AUTHENTICATION
-        ) and not connection.authenticated:
+            (self.permissions & self.WRITE_REQUIRES_AUTHENTICATION)
+            and connection is not None
+            and not connection.authenticated
+        ):
             raise ATT_Error(
                 error_code=ATT_INSUFFICIENT_AUTHENTICATION_ERROR, att_handle=self.handle
             )
@@ -912,11 +928,11 @@ class Attribute(EventEmitter):
                 error_code=ATT_INSUFFICIENT_AUTHORIZATION_ERROR, att_handle=self.handle
             )
 
-        value = self.decode_value(value_bytes)
+        decoded_value = self.decode_value(value)
 
-        if hasattr(self.value, 'write'):
+        if self.value is not None and hasattr(self.value, 'write'):
             try:
-                result = self.value.write(connection, value)
+                result = self.value.write(connection, decoded_value)
                 if inspect.isawaitable(result):
                     await result
             except ATT_Error as error:
@@ -924,9 +940,9 @@ class Attribute(EventEmitter):
                     error_code=error.error_code, att_handle=self.handle
                 ) from error
         else:
-            self.value = value
+            self.value = decoded_value
 
-        self.emit('write', connection, value)
+        self.emit('write', connection, decoded_value)
 
     def __repr__(self):
         if isinstance(self.value, bytes):

--- a/bumble/att.py
+++ b/bumble/att.py
@@ -885,9 +885,7 @@ class Attribute(EventEmitter, Generic[_T]):
             )
 
         value: Union[_T, None]
-        if self.value is None:
-            value = None
-        elif hasattr(self.value, 'read'):
+        if isinstance(self.value, AttributeValue):
             try:
                 read_value = self.value.read(connection)
                 if inspect.isawaitable(read_value):
@@ -930,7 +928,7 @@ class Attribute(EventEmitter, Generic[_T]):
 
         decoded_value = self.decode_value(value)
 
-        if self.value is not None and hasattr(self.value, 'write'):
+        if isinstance(self.value, AttributeValue):
             try:
                 result = self.value.write(connection, decoded_value)
                 if inspect.isawaitable(result):

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -53,7 +53,7 @@ from pyee import EventEmitter
 
 from .colors import color
 from .att import ATT_CID, ATT_DEFAULT_MTU, ATT_PDU
-from .gatt import Characteristic, Descriptor, Service
+from .gatt import Attribute, Characteristic, Descriptor, Service
 from .host import DataPacketQueue, Host
 from .profiles.gap import GenericAccessService
 from .core import (
@@ -2221,7 +2221,7 @@ class Device(CompositeEventEmitter):
                         permissions=descriptor["permissions"],
                     )
                     descriptors.append(new_descriptor)
-                new_characteristic = Characteristic(
+                new_characteristic: Characteristic[bytes] = Characteristic(
                     uuid=characteristic["uuid"],
                     properties=Characteristic.Properties.from_string(
                         characteristic["properties"]
@@ -4920,16 +4920,84 @@ class Device(CompositeEventEmitter):
             self.gatt_service = gatt_service.GenericAttributeProfileService()
             self.gatt_server.add_service(self.gatt_service)
 
-    async def notify_subscriber(self, connection, attribute, value=None, force=False):
+    async def notify_subscriber(
+        self,
+        connection: Connection,
+        attribute: Attribute,
+        value: Optional[Any] = None,
+        force: bool = False,
+    ) -> None:
+        """
+        Send a notification to an attribute subscriber.
+
+        Args:
+           connection:
+             The connection of the subscriber.
+           attribute:
+             The attribute whose value is notified.
+           value:
+             The value of the attribute (if None, the value is read from the attribute)
+            force:
+              If True, send a notification even if there is no subscriber.
+        """
         await self.gatt_server.notify_subscriber(connection, attribute, value, force)
 
-    async def notify_subscribers(self, attribute, value=None, force=False):
+    async def notify_subscribers(
+        self, attribute: Attribute, value=None, force=False
+    ) -> None:
+        """
+        Send a notification to all the subscribers of an attribute.
+
+        Args:
+           attribute:
+             The attribute whose value is notified.
+           value:
+             The value of the attribute (if None, the value is read from the attribute)
+            force:
+              If True, send a notification for every connection even if there is no
+              subscriber.
+        """
         await self.gatt_server.notify_subscribers(attribute, value, force)
 
-    async def indicate_subscriber(self, connection, attribute, value=None, force=False):
+    async def indicate_subscriber(
+        self,
+        connection: Connection,
+        attribute: Attribute,
+        value: Optional[Any] = None,
+        force: bool = False,
+    ):
+        """
+        Send an indication to an attribute subscriber.
+
+        This method returns when the response to the indication has been received.
+
+        Args:
+           connection:
+             The connection of the subscriber.
+           attribute:
+             The attribute whose value is indicated.
+           value:
+             The value of the attribute (if None, the value is read from the attribute)
+            force:
+              If True, send an indication even if there is no subscriber.
+        """
         await self.gatt_server.indicate_subscriber(connection, attribute, value, force)
 
-    async def indicate_subscribers(self, attribute, value=None, force=False):
+    async def indicate_subscribers(
+        self, attribute: Attribute, value: Optional[Any] = None, force: bool = False
+    ):
+        """
+        Send an indication to all the subscribers of an attribute.
+
+        Args:
+           attribute:
+             The attribute whose value is notified.
+           value:
+             The value of the attribute (if None, the value is read from the attribute)
+            force:
+              If True, send an indication for every connection even if there is no
+              subscriber.
+        """
         await self.gatt_server.indicate_subscribers(attribute, value, force)
 
     @host_event_handler

--- a/bumble/gatt_adapters.py
+++ b/bumble/gatt_adapters.py
@@ -48,10 +48,7 @@ _T3 = TypeVar('_T3', bound=IntConvertible)
 
 # -----------------------------------------------------------------------------
 class CharacteristicAdapter(Characteristic, Generic[_T]):
-    '''
-    An adapter that can adapt a Characteristic to automatically encode/decode values
-    read/written from the characteristic.
-    '''
+    '''Base class for GATT Characteristic adapters.'''
 
     def __init__(self, characteristic: Characteristic) -> None:
         super().__init__(
@@ -65,20 +62,7 @@ class CharacteristicAdapter(Characteristic, Generic[_T]):
 
 # -----------------------------------------------------------------------------
 class CharacteristicProxyAdapter(CharacteristicProxy[_T]):
-    '''
-    An adapter that can adapt Characteristic and AttributeProxy objects
-    by wrapping their `read_value()` and `write_value()` methods with ones that
-    return/accept encoded/decoded values.
-
-    For proxies (i.e used by a GATT client), the adaptation is one where the return
-    value of `read_value()` is decoded and the value passed to `write_value()` is
-    encoded. The `subscribe()` method, is wrapped with one where the values are decoded
-    before being passed to the subscriber.
-
-    For local values (i.e hosted by a GATT server) the adaptation is one where the
-    return value of `read_value()` is encoded and the value passed to `write_value()`
-    is decoded.
-    '''
+    '''Base class for GATT CharacteristicProxy adapters.'''
 
     def __init__(self, characteristic_proxy: CharacteristicProxy):
         super().__init__(

--- a/bumble/gatt_adapters.py
+++ b/bumble/gatt_adapters.py
@@ -1,0 +1,390 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# GATT - Type Adapters
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Imports
+# -----------------------------------------------------------------------------
+from __future__ import annotations
+import struct
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    Literal,
+    Optional,
+    Type,
+    TypeVar,
+)
+
+from bumble.core import InvalidOperationError
+from bumble.gatt import Characteristic
+from bumble.gatt_client import CharacteristicProxy
+from bumble.utils import ByteSerializable, IntConvertible
+
+
+# -----------------------------------------------------------------------------
+# Typing
+# -----------------------------------------------------------------------------
+_T = TypeVar('_T')
+_T2 = TypeVar('_T2', bound=ByteSerializable)
+_T3 = TypeVar('_T3', bound=IntConvertible)
+
+
+# -----------------------------------------------------------------------------
+class CharacteristicAdapter(Characteristic, Generic[_T]):
+    '''
+    An adapter that can adapt a Characteristic to automatically encode/decode values
+    read/written from the characteristic.
+    '''
+
+    def __init__(self, characteristic: Characteristic) -> None:
+        super().__init__(
+            characteristic.uuid,
+            characteristic.properties,
+            characteristic.permissions,
+            characteristic.value,
+            characteristic.descriptors,
+        )
+
+
+# -----------------------------------------------------------------------------
+class CharacteristicProxyAdapter(CharacteristicProxy[_T]):
+    '''
+    An adapter that can adapt Characteristic and AttributeProxy objects
+    by wrapping their `read_value()` and `write_value()` methods with ones that
+    return/accept encoded/decoded values.
+
+    For proxies (i.e used by a GATT client), the adaptation is one where the return
+    value of `read_value()` is decoded and the value passed to `write_value()` is
+    encoded. The `subscribe()` method, is wrapped with one where the values are decoded
+    before being passed to the subscriber.
+
+    For local values (i.e hosted by a GATT server) the adaptation is one where the
+    return value of `read_value()` is encoded and the value passed to `write_value()`
+    is decoded.
+    '''
+
+    def __init__(self, characteristic_proxy: CharacteristicProxy):
+        super().__init__(
+            characteristic_proxy.client,
+            characteristic_proxy.handle,
+            characteristic_proxy.end_group_handle,
+            characteristic_proxy.uuid,
+            characteristic_proxy.properties,
+        )
+
+
+# -----------------------------------------------------------------------------
+class DelegatedCharacteristicAdapter(CharacteristicAdapter[_T]):
+    '''
+    Adapter that converts bytes values using an encode and/or a decode function.
+    '''
+
+    def __init__(
+        self,
+        characteristic: Characteristic,
+        encode: Optional[Callable[[_T], bytes]] = None,
+        decode: Optional[Callable[[bytes], _T]] = None,
+    ):
+        super().__init__(characteristic)
+        self.encode = encode
+        self.decode = decode
+
+    def encode_value(self, value: _T) -> bytes:
+        if self.encode is None:
+            raise InvalidOperationError('delegated adapter does not have an encoder')
+        return self.encode(value)
+
+    def decode_value(self, value: bytes) -> _T:
+        if self.decode is None:
+            raise InvalidOperationError('delegate adapter does not have a decoder')
+        return self.decode(value)
+
+
+# -----------------------------------------------------------------------------
+class DelegatedCharacteristicProxyAdapter(CharacteristicProxyAdapter[_T]):
+    '''
+    Adapter that converts bytes values using an encode and a decode function.
+    '''
+
+    def __init__(
+        self,
+        characteristic_proxy: CharacteristicProxy,
+        encode: Optional[Callable[[_T], bytes]] = None,
+        decode: Optional[Callable[[bytes], _T]] = None,
+    ):
+        super().__init__(characteristic_proxy)
+        self.encode = encode
+        self.decode = decode
+
+    def encode_value(self, value: _T) -> bytes:
+        if self.encode is None:
+            raise InvalidOperationError('delegated adapter does not have an encoder')
+        return self.encode(value)
+
+    def decode_value(self, value: bytes) -> _T:
+        if self.decode is None:
+            raise InvalidOperationError('delegate adapter does not have a decoder')
+        return self.decode(value)
+
+
+# -----------------------------------------------------------------------------
+class PackedCharacteristicAdapter(CharacteristicAdapter):
+    '''
+    Adapter that packs/unpacks characteristic values according to a standard
+    Python `struct` format.
+    For formats with a single value, the adapted `read_value` and `write_value`
+    methods return/accept single values. For formats with multiple values,
+    they return/accept a tuple with the same number of elements as is required for
+    the format.
+    '''
+
+    def __init__(self, characteristic: Characteristic, pack_format: str) -> None:
+        super().__init__(characteristic)
+        self.struct = struct.Struct(pack_format)
+
+    def pack(self, *values) -> bytes:
+        return self.struct.pack(*values)
+
+    def unpack(self, buffer: bytes) -> tuple:
+        return self.struct.unpack(buffer)
+
+    def encode_value(self, value: Any) -> bytes:
+        return self.pack(*value if isinstance(value, tuple) else (value,))
+
+    def decode_value(self, value: bytes) -> Any:
+        unpacked = self.unpack(value)
+        return unpacked[0] if len(unpacked) == 1 else unpacked
+
+
+# -----------------------------------------------------------------------------
+class PackedCharacteristicProxyAdapter(CharacteristicProxyAdapter):
+    '''
+    Adapter that packs/unpacks characteristic values according to a standard
+    Python `struct` format.
+    For formats with a single value, the adapted `read_value` and `write_value`
+    methods return/accept single values. For formats with multiple values,
+    they return/accept a tuple with the same number of elements as is required for
+    the format.
+    '''
+
+    def __init__(self, characteristic_proxy, pack_format):
+        super().__init__(characteristic_proxy)
+        self.struct = struct.Struct(pack_format)
+
+    def pack(self, *values) -> bytes:
+        return self.struct.pack(*values)
+
+    def unpack(self, buffer: bytes) -> tuple:
+        return self.struct.unpack(buffer)
+
+    def encode_value(self, value: Any) -> bytes:
+        return self.pack(*value if isinstance(value, tuple) else (value,))
+
+    def decode_value(self, value: bytes) -> Any:
+        unpacked = self.unpack(value)
+        return unpacked[0] if len(unpacked) == 1 else unpacked
+
+
+# -----------------------------------------------------------------------------
+class MappedCharacteristicAdapter(PackedCharacteristicAdapter):
+    '''
+    Adapter that packs/unpacks characteristic values according to a standard
+    Python `struct` format.
+    The adapted `read_value` and `write_value` methods return/accept a dictionary which
+    is packed/unpacked according to format, with the arguments extracted from the
+    dictionary by key, in the same order as they occur in the `keys` parameter.
+    '''
+
+    def __init__(
+        self, characteristic: Characteristic, pack_format: str, keys: Iterable[str]
+    ) -> None:
+        super().__init__(characteristic, pack_format)
+        self.keys = keys
+
+    # pylint: disable=arguments-differ
+    def pack(self, values) -> bytes:
+        return super().pack(*(values[key] for key in self.keys))
+
+    def unpack(self, buffer: bytes) -> Any:
+        return dict(zip(self.keys, super().unpack(buffer)))
+
+
+# -----------------------------------------------------------------------------
+class MappedCharacteristicProxyAdapter(PackedCharacteristicProxyAdapter):
+    '''
+    Adapter that packs/unpacks characteristic values according to a standard
+    Python `struct` format.
+    The adapted `read_value` and `write_value` methods return/accept a dictionary which
+    is packed/unpacked according to format, with the arguments extracted from the
+    dictionary by key, in the same order as they occur in the `keys` parameter.
+    '''
+
+    def __init__(
+        self,
+        characteristic_proxy: CharacteristicProxy,
+        pack_format: str,
+        keys: Iterable[str],
+    ) -> None:
+        super().__init__(characteristic_proxy, pack_format)
+        self.keys = keys
+
+    # pylint: disable=arguments-differ
+    def pack(self, values) -> bytes:
+        return super().pack(*(values[key] for key in self.keys))
+
+    def unpack(self, buffer: bytes) -> Any:
+        return dict(zip(self.keys, super().unpack(buffer)))
+
+
+# -----------------------------------------------------------------------------
+class UTF8CharacteristicAdapter(CharacteristicAdapter[str]):
+    '''
+    Adapter that converts strings to/from bytes using UTF-8 encoding
+    '''
+
+    def encode_value(self, value: str) -> bytes:
+        return value.encode('utf-8')
+
+    def decode_value(self, value: bytes) -> str:
+        return value.decode('utf-8')
+
+
+# -----------------------------------------------------------------------------
+class UTF8CharacteristicProxyAdapter(CharacteristicProxyAdapter[str]):
+    '''
+    Adapter that converts strings to/from bytes using UTF-8 encoding
+    '''
+
+    def encode_value(self, value: str) -> bytes:
+        return value.encode('utf-8')
+
+    def decode_value(self, value: bytes) -> str:
+        return value.decode('utf-8')
+
+
+# -----------------------------------------------------------------------------
+class SerializableCharacteristicAdapter(CharacteristicAdapter[_T2]):
+    '''
+    Adapter that converts any class to/from bytes using the class'
+    `to_bytes` and `__bytes__` methods, respectively.
+    '''
+
+    def __init__(self, characteristic: Characteristic, cls: Type[_T2]) -> None:
+        super().__init__(characteristic)
+        self.cls = cls
+
+    def encode_value(self, value: _T2) -> bytes:
+        return bytes(value)
+
+    def decode_value(self, value: bytes) -> _T2:
+        return self.cls.from_bytes(value)
+
+
+# -----------------------------------------------------------------------------
+class SerializableCharacteristicProxyAdapter(CharacteristicProxyAdapter[_T2]):
+    '''
+    Adapter that converts any class to/from bytes using the class'
+    `to_bytes` and `__bytes__` methods, respectively.
+    '''
+
+    def __init__(
+        self, characteristic_proxy: CharacteristicProxy, cls: Type[_T2]
+    ) -> None:
+        super().__init__(characteristic_proxy)
+        self.cls = cls
+
+    def encode_value(self, value: _T2) -> bytes:
+        return bytes(value)
+
+    def decode_value(self, value: bytes) -> _T2:
+        return self.cls.from_bytes(value)
+
+
+# -----------------------------------------------------------------------------
+class EnumCharacteristicAdapter(CharacteristicAdapter[_T3]):
+    '''
+    Adapter that converts int-enum-like classes to/from bytes using the class'
+    `int().to_bytes()` and `from_bytes()` methods, respectively.
+    '''
+
+    def __init__(
+        self,
+        characteristic: Characteristic,
+        cls: Type[_T3],
+        length: int,
+        byteorder: Literal['little', 'big'] = 'little',
+    ):
+        """
+        Initialize an instance.
+
+        Params:
+          characteristic: the Characteristic to adapt to/from
+          cls: the class to/from which to convert integer values
+          length: number of bytes used to represent integer values
+          byteorder: byte order of the byte representation of integers.
+        """
+        super().__init__(characteristic)
+        self.cls = cls
+        self.length = length
+        self.byteorder = byteorder
+
+    def encode_value(self, value: _T3) -> bytes:
+        return int(value).to_bytes(self.length, self.byteorder)
+
+    def decode_value(self, value: bytes) -> _T3:
+        int_value = int.from_bytes(value, self.byteorder)
+        return self.cls(int_value)
+
+
+# -----------------------------------------------------------------------------
+class EnumCharacteristicProxyAdapter(CharacteristicProxyAdapter[_T3]):
+    '''
+    Adapter that converts int-enum-like classes to/from bytes using the class'
+    `int().to_bytes()` and `from_bytes()` methods, respectively.
+    '''
+
+    def __init__(
+        self,
+        characteristic_proxy: CharacteristicProxy,
+        cls: Type[_T3],
+        length: int,
+        byteorder: Literal['little', 'big'] = 'little',
+    ):
+        """
+        Initialize an instance.
+
+        Params:
+          characteristic_proxy: the CharacteristicProxy to adapt to/from
+          cls: the class to/from which to convert integer values
+          length: number of bytes used to represent integer values
+          byteorder: byte order of the byte representation of integers.
+        """
+        super().__init__(characteristic_proxy)
+        self.cls = cls
+        self.length = length
+        self.byteorder = byteorder
+
+    def encode_value(self, value: _T3) -> bytes:
+        return int(value).to_bytes(self.length, self.byteorder)
+
+    def decode_value(self, value: bytes) -> _T3:
+        int_value = int.from_bytes(value, self.byteorder)
+        a = self.cls(int_value)
+        return self.cls(int_value)

--- a/bumble/gatt_server.py
+++ b/bumble/gatt_server.py
@@ -36,7 +36,6 @@ from typing import (
     Tuple,
     TypeVar,
     Type,
-    Union,
     TYPE_CHECKING,
 )
 from pyee import EventEmitter
@@ -78,7 +77,6 @@ from bumble.gatt import (
     GATT_REQUEST_TIMEOUT,
     GATT_SECONDARY_SERVICE_ATTRIBUTE_TYPE,
     Characteristic,
-    CharacteristicAdapter,
     CharacteristicDeclaration,
     CharacteristicValue,
     IncludedServiceDeclaration,
@@ -469,7 +467,7 @@ class Server(EventEmitter):
             finally:
                 self.pending_confirmations[connection.handle] = None
 
-    async def notify_or_indicate_subscribers(
+    async def _notify_or_indicate_subscribers(
         self,
         indicate: bool,
         attribute: Attribute,
@@ -503,7 +501,9 @@ class Server(EventEmitter):
         value: Optional[bytes] = None,
         force: bool = False,
     ):
-        return await self.notify_or_indicate_subscribers(False, attribute, value, force)
+        return await self._notify_or_indicate_subscribers(
+            False, attribute, value, force
+        )
 
     async def indicate_subscribers(
         self,
@@ -511,7 +511,7 @@ class Server(EventEmitter):
         value: Optional[bytes] = None,
         force: bool = False,
     ):
-        return await self.notify_or_indicate_subscribers(True, attribute, value, force)
+        return await self._notify_or_indicate_subscribers(True, attribute, value, force)
 
     def on_disconnection(self, connection: Connection) -> None:
         if connection.handle in self.subscribers:

--- a/bumble/profiles/asha.py
+++ b/bumble/profiles/asha.py
@@ -134,12 +134,14 @@ class AshaService(gatt.TemplateService):
             ),
         )
 
-        self.audio_control_point_characteristic = gatt.Characteristic(
-            gatt.GATT_ASHA_AUDIO_CONTROL_POINT_CHARACTERISTIC,
-            gatt.Characteristic.Properties.WRITE
-            | gatt.Characteristic.Properties.WRITE_WITHOUT_RESPONSE,
-            gatt.Characteristic.WRITEABLE,
-            gatt.CharacteristicValue(write=self._on_audio_control_point_write),
+        self.audio_control_point_characteristic: gatt.Characteristic[bytes] = (
+            gatt.Characteristic(
+                gatt.GATT_ASHA_AUDIO_CONTROL_POINT_CHARACTERISTIC,
+                gatt.Characteristic.Properties.WRITE
+                | gatt.Characteristic.Properties.WRITE_WITHOUT_RESPONSE,
+                gatt.Characteristic.WRITEABLE,
+                gatt.CharacteristicValue(write=self._on_audio_control_point_write),
+            )
         )
         self.audio_status_characteristic = gatt.Characteristic(
             gatt.GATT_ASHA_AUDIO_STATUS_CHARACTERISTIC,
@@ -147,7 +149,7 @@ class AshaService(gatt.TemplateService):
             gatt.Characteristic.READABLE,
             bytes([AudioStatus.OK]),
         )
-        self.volume_characteristic = gatt.Characteristic(
+        self.volume_characteristic: gatt.Characteristic[bytes] = gatt.Characteristic(
             gatt.GATT_ASHA_VOLUME_CHARACTERISTIC,
             gatt.Characteristic.Properties.WRITE_WITHOUT_RESPONSE,
             gatt.Characteristic.WRITEABLE,
@@ -166,13 +168,13 @@ class AshaService(gatt.TemplateService):
             struct.pack('<H', self.psm),
         )
 
-        characteristics = [
+        characteristics = (
             self.read_only_properties_characteristic,
             self.audio_control_point_characteristic,
             self.audio_status_characteristic,
             self.volume_characteristic,
             self.le_psm_out_characteristic,
-        ]
+        )
 
         super().__init__(characteristics)
 

--- a/bumble/profiles/battery_service.py
+++ b/bumble/profiles/battery_service.py
@@ -16,14 +16,20 @@
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
-from ..gatt_client import ProfileServiceProxy
-from ..gatt import (
+from typing import Optional
+
+from bumble.gatt_client import ProfileServiceProxy
+from bumble.gatt import (
     GATT_BATTERY_SERVICE,
     GATT_BATTERY_LEVEL_CHARACTERISTIC,
     TemplateService,
     Characteristic,
     CharacteristicValue,
+)
+from bumble.gatt_client import CharacteristicProxy
+from bumble.gatt_adapters import (
     PackedCharacteristicAdapter,
+    PackedCharacteristicProxyAdapter,
 )
 
 
@@ -31,6 +37,8 @@ from ..gatt import (
 class BatteryService(TemplateService):
     UUID = GATT_BATTERY_SERVICE
     BATTERY_LEVEL_FORMAT = 'B'
+
+    battery_level_characteristic: Characteristic[int]
 
     def __init__(self, read_battery_level):
         self.battery_level_characteristic = PackedCharacteristicAdapter(
@@ -49,13 +57,15 @@ class BatteryService(TemplateService):
 class BatteryServiceProxy(ProfileServiceProxy):
     SERVICE_CLASS = BatteryService
 
+    battery_level: Optional[CharacteristicProxy[int]]
+
     def __init__(self, service_proxy):
         self.service_proxy = service_proxy
 
         if characteristics := service_proxy.get_characteristics_by_uuid(
             GATT_BATTERY_LEVEL_CHARACTERISTIC
         ):
-            self.battery_level = PackedCharacteristicAdapter(
+            self.battery_level = PackedCharacteristicProxyAdapter(
                 characteristics[0], pack_format=BatteryService.BATTERY_LEVEL_FORMAT
             )
         else:

--- a/bumble/profiles/gatt_service.py
+++ b/bumble/profiles/gatt_service.py
@@ -110,6 +110,7 @@ class GenericAttributeProfileService(gatt.TemplateService):
             gatt.GATT_CHARACTERISTIC_ATTRIBUTE_TYPE,
             gatt.GATT_CHARACTERISTIC_EXTENDED_PROPERTIES_DESCRIPTOR,
         ):
+            assert isinstance(attribute.value, bytes)
             return (
                 struct.pack("<H", attribute.handle)
                 + attribute.type.to_bytes()

--- a/bumble/profiles/gmap.py
+++ b/bumble/profiles/gmap.py
@@ -22,7 +22,6 @@ from typing import Optional
 
 from bumble.gatt import (
     TemplateService,
-    DelegatedCharacteristicAdapter,
     Characteristic,
     GATT_GAMING_AUDIO_SERVICE,
     GATT_GMAP_ROLE_CHARACTERISTIC,
@@ -31,7 +30,8 @@ from bumble.gatt import (
     GATT_BGS_FEATURES_CHARACTERISTIC,
     GATT_BGR_FEATURES_CHARACTERISTIC,
 )
-from bumble.gatt_client import ProfileServiceProxy, ServiceProxy
+from bumble.gatt_adapters import DelegatedCharacteristicProxyAdapter
+from bumble.gatt_client import CharacteristicProxy, ProfileServiceProxy, ServiceProxy
 from enum import IntFlag
 
 
@@ -150,10 +150,15 @@ class GamingAudioService(TemplateService):
 class GamingAudioServiceProxy(ProfileServiceProxy):
     SERVICE_CLASS = GamingAudioService
 
+    ugg_features: Optional[CharacteristicProxy[UggFeatures]] = None
+    ugt_features: Optional[CharacteristicProxy[UgtFeatures]] = None
+    bgs_features: Optional[CharacteristicProxy[BgsFeatures]] = None
+    bgr_features: Optional[CharacteristicProxy[BgrFeatures]] = None
+
     def __init__(self, service_proxy: ServiceProxy) -> None:
         self.service_proxy = service_proxy
 
-        self.gmap_role = DelegatedCharacteristicAdapter(
+        self.gmap_role = DelegatedCharacteristicProxyAdapter(
             service_proxy.get_required_characteristic_by_uuid(
                 GATT_GMAP_ROLE_CHARACTERISTIC
             ),
@@ -163,31 +168,31 @@ class GamingAudioServiceProxy(ProfileServiceProxy):
         if characteristics := service_proxy.get_characteristics_by_uuid(
             GATT_UGG_FEATURES_CHARACTERISTIC
         ):
-            self.ugg_features = DelegatedCharacteristicAdapter(
-                characteristic=characteristics[0],
+            self.ugg_features = DelegatedCharacteristicProxyAdapter(
+                characteristics[0],
                 decode=lambda value: UggFeatures(value[0]),
             )
 
         if characteristics := service_proxy.get_characteristics_by_uuid(
             GATT_UGT_FEATURES_CHARACTERISTIC
         ):
-            self.ugt_features = DelegatedCharacteristicAdapter(
-                characteristic=characteristics[0],
+            self.ugt_features = DelegatedCharacteristicProxyAdapter(
+                characteristics[0],
                 decode=lambda value: UgtFeatures(value[0]),
             )
 
         if characteristics := service_proxy.get_characteristics_by_uuid(
             GATT_BGS_FEATURES_CHARACTERISTIC
         ):
-            self.bgs_features = DelegatedCharacteristicAdapter(
-                characteristic=characteristics[0],
+            self.bgs_features = DelegatedCharacteristicProxyAdapter(
+                characteristics[0],
                 decode=lambda value: BgsFeatures(value[0]),
             )
 
         if characteristics := service_proxy.get_characteristics_by_uuid(
             GATT_BGR_FEATURES_CHARACTERISTIC
         ):
-            self.bgr_features = DelegatedCharacteristicAdapter(
-                characteristic=characteristics[0],
+            self.bgr_features = DelegatedCharacteristicProxyAdapter(
+                characteristics[0],
                 decode=lambda value: BgrFeatures(value[0]),
             )

--- a/bumble/profiles/hap.py
+++ b/bumble/profiles/hap.py
@@ -18,14 +18,15 @@
 from __future__ import annotations
 import asyncio
 import functools
-from bumble import att, gatt, gatt_client
+from dataclasses import dataclass, field
+import logging
+from typing import Any, Dict, List, Optional, Set, Union
+
+from bumble import att, gatt, gatt_adapters, gatt_client
 from bumble.core import InvalidArgumentError, InvalidStateError
 from bumble.device import Device, Connection
 from bumble.utils import AsyncRunner, OpenIntEnum
 from bumble.hci import Address
-from dataclasses import dataclass, field
-import logging
-from typing import Any, Dict, List, Optional, Set, Union
 
 
 # -----------------------------------------------------------------------------
@@ -631,11 +632,12 @@ class HearingAccessServiceProxy(gatt_client.ProfileServiceProxy):
 
     hearing_aid_preset_control_point: gatt_client.CharacteristicProxy
     preset_control_point_indications: asyncio.Queue
+    active_preset_index_notification: asyncio.Queue
 
     def __init__(self, service_proxy: gatt_client.ServiceProxy) -> None:
         self.service_proxy = service_proxy
 
-        self.server_features = gatt.PackedCharacteristicAdapter(
+        self.server_features = gatt_adapters.PackedCharacteristicProxyAdapter(
             service_proxy.get_characteristics_by_uuid(
                 gatt.GATT_HEARING_AID_FEATURES_CHARACTERISTIC
             )[0],
@@ -648,7 +650,7 @@ class HearingAccessServiceProxy(gatt_client.ProfileServiceProxy):
             )[0]
         )
 
-        self.active_preset_index = gatt.PackedCharacteristicAdapter(
+        self.active_preset_index = gatt_adapters.PackedCharacteristicProxyAdapter(
             service_proxy.get_characteristics_by_uuid(
                 gatt.GATT_ACTIVE_PRESET_INDEX_CHARACTERISTIC
             )[0],

--- a/bumble/profiles/heart_rate_service.py
+++ b/bumble/profiles/heart_rate_service.py
@@ -16,13 +16,14 @@
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
+from __future__ import annotations
 from enum import IntEnum
 import struct
+from typing import Optional
 
 from bumble import core
-from ..gatt_client import ProfileServiceProxy
-from ..att import ATT_Error
-from ..gatt import (
+from bumble.att import ATT_Error
+from bumble.gatt import (
     GATT_HEART_RATE_SERVICE,
     GATT_HEART_RATE_MEASUREMENT_CHARACTERISTIC,
     GATT_BODY_SENSOR_LOCATION_CHARACTERISTIC,
@@ -30,10 +31,13 @@ from ..gatt import (
     TemplateService,
     Characteristic,
     CharacteristicValue,
-    SerializableCharacteristicAdapter,
+)
+from bumble.gatt_adapters import (
     DelegatedCharacteristicAdapter,
     PackedCharacteristicAdapter,
+    SerializableCharacteristicAdapter,
 )
+from bumble.gatt_client import CharacteristicProxy, ProfileServiceProxy
 
 
 # -----------------------------------------------------------------------------
@@ -42,6 +46,10 @@ class HeartRateService(TemplateService):
     HEART_RATE_CONTROL_POINT_FORMAT = 'B'
     CONTROL_POINT_NOT_SUPPORTED = 0x80
     RESET_ENERGY_EXPENDED = 0x01
+
+    heart_rate_measurement_characteristic: Characteristic[HeartRateMeasurement]
+    body_sensor_location_characteristic: Characteristic[BodySensorLocation]
+    heart_rate_control_point_characteristic: Characteristic[int]
 
     class BodySensorLocation(IntEnum):
         OTHER = 0
@@ -197,6 +205,14 @@ class HeartRateService(TemplateService):
 # -----------------------------------------------------------------------------
 class HeartRateServiceProxy(ProfileServiceProxy):
     SERVICE_CLASS = HeartRateService
+
+    heart_rate_measurement: Optional[
+        CharacteristicProxy[HeartRateService.HeartRateMeasurement]
+    ]
+    body_sensor_location: Optional[
+        CharacteristicProxy[HeartRateService.BodySensorLocation]
+    ]
+    heart_rate_control_point: Optional[CharacteristicProxy[int]]
 
     def __init__(self, service_proxy):
         self.service_proxy = service_proxy

--- a/bumble/profiles/mcp.py
+++ b/bumble/profiles/mcp.py
@@ -208,7 +208,7 @@ class MediaControlService(gatt.TemplateService):
             properties=gatt.Characteristic.Properties.READ
             | gatt.Characteristic.Properties.NOTIFY,
             permissions=gatt.Characteristic.Permissions.READ_REQUIRES_ENCRYPTION,
-            value=media_player_name or 'Bumble Player',
+            value=(media_player_name or 'Bumble Player').encode(),
         )
         self.track_changed_characteristic = gatt.Characteristic(
             uuid=gatt.GATT_TRACK_CHANGED_CHARACTERISTIC,
@@ -247,14 +247,16 @@ class MediaControlService(gatt.TemplateService):
             permissions=gatt.Characteristic.Permissions.READ_REQUIRES_ENCRYPTION,
             value=b'',
         )
-        self.media_control_point_characteristic = gatt.Characteristic(
-            uuid=gatt.GATT_MEDIA_CONTROL_POINT_CHARACTERISTIC,
-            properties=gatt.Characteristic.Properties.WRITE
-            | gatt.Characteristic.Properties.WRITE_WITHOUT_RESPONSE
-            | gatt.Characteristic.Properties.NOTIFY,
-            permissions=gatt.Characteristic.Permissions.READ_REQUIRES_ENCRYPTION
-            | gatt.Characteristic.Permissions.WRITE_REQUIRES_ENCRYPTION,
-            value=gatt.CharacteristicValue(write=self.on_media_control_point),
+        self.media_control_point_characteristic: gatt.Characteristic[bytes] = (
+            gatt.Characteristic(
+                uuid=gatt.GATT_MEDIA_CONTROL_POINT_CHARACTERISTIC,
+                properties=gatt.Characteristic.Properties.WRITE
+                | gatt.Characteristic.Properties.WRITE_WITHOUT_RESPONSE
+                | gatt.Characteristic.Properties.NOTIFY,
+                permissions=gatt.Characteristic.Permissions.READ_REQUIRES_ENCRYPTION
+                | gatt.Characteristic.Permissions.WRITE_REQUIRES_ENCRYPTION,
+                value=gatt.CharacteristicValue(write=self.on_media_control_point),
+            )
         )
         self.media_control_point_opcodes_supported_characteristic = gatt.Characteristic(
             uuid=gatt.GATT_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED_CHARACTERISTIC,

--- a/bumble/profiles/tmap.py
+++ b/bumble/profiles/tmap.py
@@ -24,11 +24,11 @@ import struct
 from bumble.gatt import (
     TemplateService,
     Characteristic,
-    DelegatedCharacteristicAdapter,
     GATT_TELEPHONY_AND_MEDIA_AUDIO_SERVICE,
     GATT_TMAP_ROLE_CHARACTERISTIC,
 )
-from bumble.gatt_client import ProfileServiceProxy, ServiceProxy
+from bumble.gatt_adapters import DelegatedCharacteristicProxyAdapter
+from bumble.gatt_client import CharacteristicProxy, ProfileServiceProxy, ServiceProxy
 
 
 # -----------------------------------------------------------------------------
@@ -53,6 +53,8 @@ class Role(enum.IntFlag):
 class TelephonyAndMediaAudioService(TemplateService):
     UUID = GATT_TELEPHONY_AND_MEDIA_AUDIO_SERVICE
 
+    role_characteristic: Characteristic[bytes]
+
     def __init__(self, role: Role):
         self.role_characteristic = Characteristic(
             GATT_TMAP_ROLE_CHARACTERISTIC,
@@ -68,12 +70,12 @@ class TelephonyAndMediaAudioService(TemplateService):
 class TelephonyAndMediaAudioServiceProxy(ProfileServiceProxy):
     SERVICE_CLASS = TelephonyAndMediaAudioService
 
-    role: DelegatedCharacteristicAdapter
+    role: CharacteristicProxy[Role]
 
     def __init__(self, service_proxy: ServiceProxy):
         self.service_proxy = service_proxy
 
-        self.role = DelegatedCharacteristicAdapter(
+        self.role = DelegatedCharacteristicProxyAdapter(
             service_proxy.get_required_characteristic_by_uuid(
                 GATT_TMAP_ROLE_CHARACTERISTIC
             ),

--- a/bumble/profiles/vcs.py
+++ b/bumble/profiles/vcs.py
@@ -25,6 +25,7 @@ from typing import Optional, Sequence
 from bumble import att
 from bumble import device
 from bumble import gatt
+from bumble import gatt_adapters
 from bumble import gatt_client
 
 
@@ -209,14 +210,14 @@ class VolumeControlService(gatt.TemplateService):
 class VolumeControlServiceProxy(gatt_client.ProfileServiceProxy):
     SERVICE_CLASS = VolumeControlService
 
-    volume_control_point: gatt_client.CharacteristicProxy
-    volume_state: gatt.SerializableCharacteristicAdapter
-    volume_flags: gatt.DelegatedCharacteristicAdapter
+    volume_control_point: gatt_client.CharacteristicProxy[bytes]
+    volume_state: gatt_client.CharacteristicProxy[VolumeState]
+    volume_flags: gatt_client.CharacteristicProxy[VolumeFlags]
 
     def __init__(self, service_proxy: gatt_client.ServiceProxy) -> None:
         self.service_proxy = service_proxy
 
-        self.volume_state = gatt.SerializableCharacteristicAdapter(
+        self.volume_state = gatt_adapters.SerializableCharacteristicProxyAdapter(
             service_proxy.get_required_characteristic_by_uuid(
                 gatt.GATT_VOLUME_STATE_CHARACTERISTIC
             ),
@@ -227,7 +228,7 @@ class VolumeControlServiceProxy(gatt_client.ProfileServiceProxy):
             gatt.GATT_VOLUME_CONTROL_POINT_CHARACTERISTIC
         )
 
-        self.volume_flags = gatt.DelegatedCharacteristicAdapter(
+        self.volume_flags = gatt_adapters.DelegatedCharacteristicProxyAdapter(
             service_proxy.get_required_characteristic_by_uuid(
                 gatt.GATT_VOLUME_FLAGS_CHARACTERISTIC
             ),

--- a/bumble/utils.py
+++ b/bumble/utils.py
@@ -502,3 +502,13 @@ class ByteSerializable(Protocol):
     def from_bytes(cls, data: bytes) -> Self: ...
 
     def __bytes__(self) -> bytes: ...
+
+
+# -----------------------------------------------------------------------------
+class IntConvertible(Protocol):
+    """
+    Type protocol for classes that can be instantiated from int and converted to int.
+    """
+
+    def __init__(self, value: int) -> None: ...
+    def __int__(self) -> int: ...

--- a/examples/heart_rate_server.py
+++ b/examples/heart_rate_server.py
@@ -102,7 +102,6 @@ async def main() -> None:
         )
 
         # Notify subscribers of the current value as soon as they subscribe
-        @heart_rate_service.heart_rate_measurement_characteristic.on('subscription')
         def on_subscription(connection, notify_enabled, indicate_enabled):
             if notify_enabled or indicate_enabled:
                 AsyncRunner.spawn(
@@ -111,6 +110,10 @@ async def main() -> None:
                         heart_rate_service.heart_rate_measurement_characteristic,
                     )
                 )
+
+        heart_rate_service.heart_rate_measurement_characteristic.on(
+            'subscription', on_subscription
+        )
 
         # Go!
         await device.power_on()

--- a/examples/run_gatt_client_and_server.py
+++ b/examples/run_gatt_client_and_server.py
@@ -70,13 +70,13 @@ async def main() -> None:
     descriptor = Descriptor(
         GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR,
         Descriptor.READABLE,
-        'My Description',
+        'My Description'.encode(),
     )
-    manufacturer_name_characteristic = Characteristic(
+    manufacturer_name_characteristic = Characteristic[bytes](
         GATT_MANUFACTURER_NAME_STRING_CHARACTERISTIC,
         Characteristic.Properties.READ,
         Characteristic.READABLE,
-        "Fitbit",
+        "Fitbit".encode(),
         [descriptor],
     )
     device_info_service = Service(

--- a/examples/run_gatt_server.py
+++ b/examples/run_gatt_server.py
@@ -94,13 +94,13 @@ async def main() -> None:
         descriptor = Descriptor(
             GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR,
             Descriptor.READABLE,
-            'My Description',
+            'My Description'.encode(),
         )
         manufacturer_name_characteristic = Characteristic(
             GATT_MANUFACTURER_NAME_STRING_CHARACTERISTIC,
             Characteristic.Properties.READ,
             Characteristic.READABLE,
-            'Fitbit',
+            'Fitbit'.encode(),
             [descriptor],
         )
         device_info_service = Service(

--- a/tests/gatt_service_test.py
+++ b/tests/gatt_service_test.py
@@ -16,6 +16,7 @@
 # Imports
 # -----------------------------------------------------------------------------
 from __future__ import annotations
+import pytest
 
 from . import test_utils
 
@@ -25,6 +26,7 @@ from bumble.profiles import gatt_service
 
 
 # -----------------------------------------------------------------------------
+@pytest.mark.asyncio
 async def test_database_hash():
     devices = await test_utils.TwoDevices.create_with_connection()
     devices[0].gatt_server.services.clear()
@@ -118,6 +120,7 @@ async def test_database_hash():
 
 
 # -----------------------------------------------------------------------------
+@pytest.mark.asyncio
 async def test_service_changed():
     devices = await test_utils.TwoDevices.create_with_connection()
     assert (service := devices[0].gatt_service)

--- a/tests/gmap_test.py
+++ b/tests/gmap_test.py
@@ -78,7 +78,11 @@ async def test_init_service(gmap_client: GamingAudioServiceProxy):
         | GmapRole.BROADCAST_GAME_RECEIVER
         | GmapRole.BROADCAST_GAME_SENDER
     )
+    assert gmap_client.ugg_features is not None
     assert await gmap_client.ugg_features.read_value() == UggFeatures.UGG_MULTISINK
+    assert gmap_client.ugt_features is not None
     assert await gmap_client.ugt_features.read_value() == UgtFeatures.UGT_SOURCE
+    assert gmap_client.bgr_features is not None
     assert await gmap_client.bgr_features.read_value() == BgrFeatures.BGR_MULTISINK
+    assert gmap_client.bgs_features is not None
     assert await gmap_client.bgs_features.read_value() == BgsFeatures.BGS_96_KBPS


### PR DESCRIPTION
This change refactors the way GATT adapter classes work, in order to offer a cleaner approach that supports proper typing annotations.
For this to work, the adapter classes had to be split in two categories: adapters for server-side characteristics and adapters for client-side characteristic proxies. The previous model attempted to combine those into a single set of adapter classes that could dynamically "patch" the class with different methods depending on whether it was client-side or server-side, but that's a hack that doesn't work well (my fault :-( ) and makes it practically impossible to properly express the typing annotations.
This new approach allows adapters to be generic classes, and those correctly present what underlying type a characteristic can hold (with transformation to/from bytes) and which types a `read_value` returns or `write_value` accepts, for characteristic proxies.
The change shouldn't be a major burden for current users of the adapter classes. The only need to:
1/ import `gatt_adapters` instead of just `gatt` to get the new adapter classes
2/ use `SomeClassProxyAdapter` rather than `SomeClassAdapter` for characteristic proxy adapters.
The adapter functionality itself is unchanged.
A new adapter class is also included, which makes it easy to support characteristics that have a single typed value that can be represented as an int (typically mapped to an `IntEnum` or `IntFlag` type in Python).
