### PR TITLE
FIX - acl_packet_queue.flush 

### DIFF
--- a/bumble/host.py
+++ b/bumble/host.py
@@ -1062,8 +1062,10 @@ class Host(AbortableEventEmitter):
             )
 
             # Flush the data queues
-            self.acl_packet_queue.flush(handle)
-            self.le_acl_packet_queue.flush(handle)
+            if self.acl_packet_queue:
+                self.acl_packet_queue.flush(handle)
+            if self.le_acl_packet_queue:
+                self.le_acl_packet_queue.flush(handle)
             if self.iso_packet_queue:
                 self.iso_packet_queue.flush(handle)
         else:


### PR DESCRIPTION
Host raises `AttributeError` exception (NoneType hs no attribute flush) for `self.acl_packet_queue.flush()` when the Controller does not support the `hci.HCI_BUFFER_SIZE_COMMAND `(e.g. the Laird 654 Connectivity Dongle for the official Bluetooth SIG Qualification PTS tests). 

