### PR TITLE
Fixed le_scan_interval incorrectly being set with scan_window

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -3091,7 +3091,7 @@ class Device(CompositeEventEmitter):
                 # pylint: disable=line-too-long
                 hci.HCI_LE_Set_Scan_Parameters_Command(
                     le_scan_type=scan_type,
-                    le_scan_interval=int(scan_window / 0.625),
+                    le_scan_interval=int(scan_interval / 0.625),
                     le_scan_window=int(scan_window / 0.625),
                     own_address_type=own_address_type,
                     scanning_filter_policy=hci.HCI_LE_Set_Scan_Parameters_Command.BASIC_UNFILTERED_POLICY,


### PR DESCRIPTION
Typo was causing LE scanning duty cycle to be locked at 100% due to the le_scan_window and le_scan_interval both being set to scan window.