### PR TITLE
add broadcast code encoding

### DIFF
--- a/bumble/profiles/pbp.py
+++ b/bumble/profiles/pbp.py
@@ -40,7 +40,7 @@ class PublicBroadcastAnnouncement:
     def from_bytes(cls, data: bytes) -> Self:
         features = cls.Features(data[0])
         metadata_length = data[1]
-        metadata_ltv = data[1 : 1 + metadata_length]
+        metadata_ltv = data[2 : 2 + metadata_length]
         return cls(
             features=features, metadata=le_audio.Metadata.from_bytes(metadata_ltv)
         )

--- a/bumble/transport/common.py
+++ b/bumble/transport/common.py
@@ -302,7 +302,10 @@ class ParserSource(BaseSource):
 # -----------------------------------------------------------------------------
 class StreamPacketSource(asyncio.Protocol, ParserSource):
     def data_received(self, data: bytes) -> None:
-        self.parser.feed_data(data)
+        try:
+            self.parser.feed_data(data)
+        except core.InvalidPacketError:
+            logger.warning("invalid packet, ignoring data")
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/transport/common.py
+++ b/bumble/transport/common.py
@@ -139,6 +139,7 @@ class PacketParser:
                         packet_type
                     ) or self.extended_packet_info.get(packet_type)
                     if self.packet_info is None:
+                        self.reset()
                         raise core.InvalidPacketError(
                             f'invalid packet type {packet_type}'
                         )


### PR DESCRIPTION
Support for proper encoding of broadcast code from strings to 16-byte values.
Also includes a fix for parsing `PublicBroadcastAnnouncement` correctly and printing more info about BIGs.
