### PR TITLE
Fix L2CAP signaling packet identifiers

### DIFF
--- a/bumble/l2cap.py
+++ b/bumble/l2cap.py
@@ -1521,6 +1521,9 @@ class ChannelManager:
 
     def next_identifier(self, connection: Connection) -> int:
         identifier = (self.identifiers.setdefault(connection.handle, 0) + 1) % 256
+        # 0x00 is an invalid ID (BT Core Spec, Vol 3, Part A, Sect 4
+        if identifier == 0:
+            identifier = 1
         self.identifiers[connection.handle] = identifier
         return identifier
 


### PR DESCRIPTION
According to the Bluetooth Core Spec, Volume 3, Part A, Section 4, 0x00 is an invalid identifier:

 4. Signaling packet formats ...
    Identifier (1 octet)

    ... Signaling identifier 0x00 is an invalid identifier and shall never be used in any command.