### PR TITLE
Cleanup relative imports

### DIFF
--- a/bumble/a2dp.py
+++ b/bumble/a2dp.py
@@ -26,9 +26,9 @@ from typing import Awaitable, Callable
 from typing_extensions import ClassVar, Self
 
 
-from .codecs import AacAudioRtpPacket
-from .company_ids import COMPANY_IDENTIFIERS
-from .sdp import (
+from bumble.codecs import AacAudioRtpPacket
+from bumble.company_ids import COMPANY_IDENTIFIERS
+from bumble.sdp import (
     DataElement,
     ServiceAttribute,
     SDP_PUBLIC_BROWSE_ROOT,
@@ -38,7 +38,7 @@ from .sdp import (
     SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID,
     SDP_BLUETOOTH_PROFILE_DESCRIPTOR_LIST_ATTRIBUTE_ID,
 )
-from .core import (
+from bumble.core import (
     BT_L2CAP_PROTOCOL_ID,
     BT_AUDIO_SOURCE_SERVICE,
     BT_AUDIO_SINK_SERVICE,
@@ -46,7 +46,7 @@ from .core import (
     BT_ADVANCED_AUDIO_DISTRIBUTION_SERVICE,
     name_or_number,
 )
-from .rtp import MediaPacket
+from bumble.rtp import MediaPacket
 
 
 # -----------------------------------------------------------------------------
@@ -155,7 +155,7 @@ def flags_to_list(flags, values):
 # -----------------------------------------------------------------------------
 def make_audio_source_service_sdp_records(service_record_handle, version=(1, 3)):
     # pylint: disable=import-outside-toplevel
-    from .avdtp import AVDTP_PSM
+    from bumble.avdtp import AVDTP_PSM
 
     version_int = version[0] << 8 | version[1]
     return [
@@ -209,7 +209,7 @@ def make_audio_source_service_sdp_records(service_record_handle, version=(1, 3))
 # -----------------------------------------------------------------------------
 def make_audio_sink_service_sdp_records(service_record_handle, version=(1, 3)):
     # pylint: disable=import-outside-toplevel
-    from .avdtp import AVDTP_PSM
+    from bumble.avdtp import AVDTP_PSM
 
     version_int = version[0] << 8 | version[1]
     return [

--- a/bumble/avdtp.py
+++ b/bumble/avdtp.py
@@ -39,14 +39,14 @@ from typing import (
 
 from pyee import EventEmitter
 
-from .core import (
+from bumble.core import (
     BT_ADVANCED_AUDIO_DISTRIBUTION_SERVICE,
     InvalidStateError,
     ProtocolError,
     InvalidArgumentError,
     name_or_number,
 )
-from .a2dp import (
+from bumble.a2dp import (
     A2DP_CODEC_TYPE_NAMES,
     A2DP_MPEG_2_4_AAC_CODEC_TYPE,
     A2DP_NON_A2DP_CODEC_TYPE,
@@ -56,9 +56,9 @@ from .a2dp import (
     SbcMediaCodecInformation,
     VendorSpecificMediaCodecInformation,
 )
-from .rtp import MediaPacket
-from . import sdp, device, l2cap
-from .colors import color
+from bumble.rtp import MediaPacket
+from bumble import sdp, device, l2cap
+from bumble.colors import color
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/bridge.py
+++ b/bumble/bridge.py
@@ -17,8 +17,8 @@
 # -----------------------------------------------------------------------------
 import logging
 
-from .hci import HCI_Packet
-from .helpers import PacketTracer
+from bumble.hci import HCI_Packet
+from bumble.helpers import PacketTracer
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -51,12 +51,12 @@ from typing_extensions import Self
 
 from pyee import EventEmitter
 
-from .colors import color
-from .att import ATT_CID, ATT_DEFAULT_MTU, ATT_PDU
-from .gatt import Attribute, Characteristic, Descriptor, Service
-from .host import DataPacketQueue, Host
-from .profiles.gap import GenericAccessService
-from .core import (
+from bumble.colors import color
+from bumble.att import ATT_CID, ATT_DEFAULT_MTU, ATT_PDU
+from bumble.gatt import Attribute, Characteristic, Descriptor, Service
+from bumble.host import DataPacketQueue, Host
+from bumble.profiles.gap import GenericAccessService
+from bumble.core import (
     PhysicalTransport,
     AdvertisingData,
     BaseBumbleError,
@@ -71,7 +71,7 @@ from .core import (
     OutOfResourcesError,
     UnreachableError,
 )
-from .utils import (
+from bumble.utils import (
     AsyncRunner,
     CompositeEventEmitter,
     EventWatcher,
@@ -80,7 +80,7 @@ from .utils import (
     deprecated,
     experimental,
 )
-from .keys import (
+from bumble.keys import (
     KeyStore,
     PairingKeys,
 )
@@ -95,7 +95,7 @@ from bumble import core
 from bumble.profiles import gatt_service
 
 if TYPE_CHECKING:
-    from .transport.common import TransportSource, TransportSink
+    from bumble.transport.common import TransportSource, TransportSink
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/drivers/__init__.py
+++ b/bumble/drivers/__init__.py
@@ -25,8 +25,8 @@ import pathlib
 import platform
 from typing import Dict, Iterable, Optional, Type, TYPE_CHECKING
 
-from . import rtk, intel
-from .common import Driver
+from bumble.drivers import rtk, intel
+from bumble.drivers.common import Driver
 
 if TYPE_CHECKING:
     from bumble.host import Host

--- a/bumble/gap.py
+++ b/bumble/gap.py
@@ -18,7 +18,7 @@
 import logging
 import struct
 
-from .gatt import (
+from bumble.gatt import (
     Service,
     Characteristic,
     GATT_GENERIC_ACCESS_SERVICE,

--- a/bumble/gatt_client.py
+++ b/bumble/gatt_client.py
@@ -46,9 +46,9 @@ from typing import (
 
 from pyee import EventEmitter
 
-from .colors import color
-from .hci import HCI_Constant
-from .att import (
+from bumble.colors import color
+from bumble.hci import HCI_Constant
+from bumble.att import (
     ATT_ATTRIBUTE_NOT_FOUND_ERROR,
     ATT_ATTRIBUTE_NOT_LONG_ERROR,
     ATT_CID,
@@ -69,9 +69,9 @@ from .att import (
     ATT_Write_Request,
     ATT_Error,
 )
-from . import core
-from .core import UUID, InvalidStateError
-from .gatt import (
+from bumble import core
+from bumble.core import UUID, InvalidStateError
+from bumble.gatt import (
     GATT_CHARACTERISTIC_ATTRIBUTE_TYPE,
     GATT_CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR,
     GATT_PRIMARY_SERVICE_ATTRIBUTE_TYPE,

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -51,7 +51,7 @@ from bumble.utils import AbortableEventEmitter
 from bumble.transport.common import TransportLostError
 
 if TYPE_CHECKING:
-    from .transport.common import TransportSink, TransportSource
+    from bumble.transport.common import TransportSink, TransportSource
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/keys.py
+++ b/bumble/keys.py
@@ -28,11 +28,11 @@ import json
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type
 from typing_extensions import Self
 
-from .colors import color
-from .hci import Address
+from bumble.colors import color
+from bumble.hci import Address
 
 if TYPE_CHECKING:
-    from .device import Device
+    from bumble.device import Device
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/l2cap.py
+++ b/bumble/l2cap.py
@@ -39,16 +39,16 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from .utils import deprecated
-from .colors import color
-from .core import (
+from bumble.utils import deprecated
+from bumble.colors import color
+from bumble.core import (
     InvalidStateError,
     InvalidArgumentError,
     InvalidPacketError,
     OutOfResourcesError,
     ProtocolError,
 )
-from .hci import (
+from bumble.hci import (
     HCI_LE_Connection_Update_Command,
     HCI_Object,
     Role,

--- a/bumble/pairing.py
+++ b/bumble/pairing.py
@@ -20,14 +20,14 @@ import enum
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from .hci import (
+from bumble.hci import (
     Address,
     HCI_NO_INPUT_NO_OUTPUT_IO_CAPABILITY,
     HCI_DISPLAY_ONLY_IO_CAPABILITY,
     HCI_DISPLAY_YES_NO_IO_CAPABILITY,
     HCI_KEYBOARD_ONLY_IO_CAPABILITY,
 )
-from .smp import (
+from bumble.smp import (
     SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY,
     SMP_KEYBOARD_ONLY_IO_CAPABILITY,
     SMP_DISPLAY_ONLY_IO_CAPABILITY,
@@ -41,7 +41,7 @@ from .smp import (
     OobLegacyContext,
     OobSharedData,
 )
-from .core import AdvertisingData, LeRole
+from bumble.core import AdvertisingData, LeRole
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/pandora/__init__.py
+++ b/bumble/pandora/__init__.py
@@ -22,11 +22,11 @@ __version__ = "0.0.1"
 import grpc
 import grpc.aio
 
-from .config import Config
-from .device import PandoraDevice
-from .host import HostService
-from .l2cap import L2CAPService
-from .security import SecurityService, SecurityStorageService
+from bumble.pandora.config import Config
+from bumble.pandora.device import PandoraDevice
+from bumble.pandora.host import HostService
+from bumble.pandora.l2cap import L2CAPService
+from bumble.pandora.security import SecurityService, SecurityStorageService
 from pandora.host_grpc_aio import add_HostServicer_to_server
 from pandora.l2cap_grpc_aio import add_L2CAPServicer_to_server
 from pandora.security_grpc_aio import (

--- a/bumble/pandora/host.py
+++ b/bumble/pandora/host.py
@@ -20,8 +20,8 @@ import grpc.aio
 import logging
 import struct
 
-from . import utils
-from .config import Config
+from bumble.pandora import utils
+from bumble.pandora.config import Config
 from bumble.core import (
     PhysicalTransport,
     UUID,

--- a/bumble/pandora/l2cap.py
+++ b/bumble/pandora/l2cap.py
@@ -19,8 +19,8 @@ import logging
 
 from asyncio import Queue as AsyncQueue, Future
 
-from . import utils
-from .config import Config
+from bumble.pandora import utils
+from bumble.pandora.config import Config
 from bumble.core import OutOfResourcesError, InvalidArgumentError
 from bumble.device import Device
 from bumble.l2cap import (

--- a/bumble/pandora/security.py
+++ b/bumble/pandora/security.py
@@ -18,8 +18,8 @@ import contextlib
 import grpc
 import logging
 
-from . import utils
-from .config import Config
+from bumble.pandora import utils
+from bumble.pandora.config import Config
 from bumble import hci
 from bumble.core import (
     PhysicalTransport,

--- a/bumble/rfcomm.py
+++ b/bumble/rfcomm.py
@@ -30,8 +30,8 @@ from pyee import EventEmitter
 from bumble import core
 from bumble import l2cap
 from bumble import sdp
-from .colors import color
-from .core import (
+from bumble.colors import color
+from bumble.core import (
     UUID,
     BT_RFCOMM_PROTOCOL_ID,
     PhysicalTransport,

--- a/bumble/sdp.py
+++ b/bumble/sdp.py
@@ -33,7 +33,7 @@ from bumble.core import (
 from bumble.hci import HCI_Object, name_or_number, key_with_value
 
 if TYPE_CHECKING:
-    from .device import Device, Connection
+    from bumble.device import Device, Connection
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -43,23 +43,23 @@ from typing import (
 
 from pyee import EventEmitter
 
-from .colors import color
-from .hci import (
+from bumble.colors import color
+from bumble.hci import (
     Address,
     Role,
     HCI_LE_Enable_Encryption_Command,
     HCI_Object,
     key_with_value,
 )
-from .core import (
+from bumble.core import (
     PhysicalTransport,
     AdvertisingData,
     InvalidArgumentError,
     ProtocolError,
     name_or_number,
 )
-from .keys import PairingKeys
-from . import crypto
+from bumble.keys import PairingKeys
+from bumble import crypto
 
 if TYPE_CHECKING:
     from bumble.device import Connection, Device

--- a/bumble/transport/__init__.py
+++ b/bumble/transport/__init__.py
@@ -20,8 +20,13 @@ import logging
 import os
 from typing import Optional
 
-from .common import Transport, AsyncPipeSink, SnoopingTransport, TransportSpecError
-from ..snoop import create_snooper
+from bumble.transport.common import (
+    Transport,
+    AsyncPipeSink,
+    SnoopingTransport,
+    TransportSpecError,
+)
+from bumble.snoop import create_snooper
 
 # -----------------------------------------------------------------------------
 # Logging
@@ -108,80 +113,80 @@ async def _open_transport(scheme: str, spec: Optional[str]) -> Transport:
     # pylint: disable=too-many-return-statements
 
     if scheme == 'serial' and spec:
-        from .serial import open_serial_transport
+        from bumble.transport.serial import open_serial_transport
 
         return await open_serial_transport(spec)
 
     if scheme == 'udp' and spec:
-        from .udp import open_udp_transport
+        from bumble.transport.udp import open_udp_transport
 
         return await open_udp_transport(spec)
 
     if scheme == 'tcp-client' and spec:
-        from .tcp_client import open_tcp_client_transport
+        from bumble.transport.tcp_client import open_tcp_client_transport
 
         return await open_tcp_client_transport(spec)
 
     if scheme == 'tcp-server' and spec:
-        from .tcp_server import open_tcp_server_transport
+        from bumble.transport.tcp_server import open_tcp_server_transport
 
         return await open_tcp_server_transport(spec)
 
     if scheme == 'ws-client' and spec:
-        from .ws_client import open_ws_client_transport
+        from bumble.transport.ws_client import open_ws_client_transport
 
         return await open_ws_client_transport(spec)
 
     if scheme == 'ws-server' and spec:
-        from .ws_server import open_ws_server_transport
+        from bumble.transport.ws_server import open_ws_server_transport
 
         return await open_ws_server_transport(spec)
 
     if scheme == 'pty':
-        from .pty import open_pty_transport
+        from bumble.transport.pty import open_pty_transport
 
         return await open_pty_transport(spec)
 
     if scheme == 'file':
-        from .file import open_file_transport
+        from bumble.transport.file import open_file_transport
 
         assert spec is not None
         return await open_file_transport(spec)
 
     if scheme == 'vhci':
-        from .vhci import open_vhci_transport
+        from bumble.transport.vhci import open_vhci_transport
 
         return await open_vhci_transport(spec)
 
     if scheme == 'hci-socket':
-        from .hci_socket import open_hci_socket_transport
+        from bumble.transport.hci_socket import open_hci_socket_transport
 
         return await open_hci_socket_transport(spec)
 
     if scheme == 'usb':
-        from .usb import open_usb_transport
+        from bumble.transport.usb import open_usb_transport
 
         assert spec
         return await open_usb_transport(spec)
 
     if scheme == 'pyusb':
-        from .pyusb import open_pyusb_transport
+        from bumble.transport.pyusb import open_pyusb_transport
 
         assert spec
         return await open_pyusb_transport(spec)
 
     if scheme == 'android-emulator':
-        from .android_emulator import open_android_emulator_transport
+        from bumble.transport.android_emulator import open_android_emulator_transport
 
         return await open_android_emulator_transport(spec)
 
     if scheme == 'android-netsim':
-        from .android_netsim import open_android_netsim_transport
+        from bumble.transport.android_netsim import open_android_netsim_transport
 
         return await open_android_netsim_transport(spec)
 
     if scheme == 'unix':
-        from .unix import open_unix_client_transport
+        from bumble.transport.unix import open_unix_client_transport
 
         assert spec
         return await open_unix_client_transport(spec)
@@ -204,8 +209,8 @@ async def open_transport_or_link(name: str) -> Transport:
     """
     if name.startswith('link-relay:'):
         logger.warning('Link Relay has been deprecated.')
-        from ..controller import Controller
-        from ..link import RemoteLink  # lazy import
+        from bumble.controller import Controller
+        from bumble.link import RemoteLink  # lazy import
 
         link = RemoteLink(name[11:])
         await link.wait_until_connected()

--- a/bumble/transport/android_emulator.py
+++ b/bumble/transport/android_emulator.py
@@ -20,7 +20,7 @@ import grpc.aio
 
 from typing import Optional, Union
 
-from .common import (
+from bumble.transport.common import (
     PumpedTransport,
     PumpedPacketSource,
     PumpedPacketSink,
@@ -29,9 +29,13 @@ from .common import (
 )
 
 # pylint: disable=no-name-in-module
-from .grpc_protobuf.emulated_bluetooth_pb2_grpc import EmulatedBluetoothServiceStub
-from .grpc_protobuf.emulated_bluetooth_packets_pb2 import HCIPacket
-from .grpc_protobuf.emulated_bluetooth_vhci_pb2_grpc import VhciForwardingServiceStub
+from bumble.transport.grpc_protobuf.emulated_bluetooth_pb2_grpc import (
+    EmulatedBluetoothServiceStub,
+)
+from bumble.transport.grpc_protobuf.emulated_bluetooth_packets_pb2 import HCIPacket
+from bumble.transport.grpc_protobuf.emulated_bluetooth_vhci_pb2_grpc import (
+    VhciForwardingServiceStub,
+)
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/transport/android_netsim.py
+++ b/bumble/transport/android_netsim.py
@@ -38,15 +38,18 @@ from bumble.transport.common import (
 )
 
 # pylint: disable=no-name-in-module
-from .grpc_protobuf.netsim.packet_streamer_pb2_grpc import (
+from bumble.transport.grpc_protobuf.netsim.packet_streamer_pb2_grpc import (
     PacketStreamerStub,
     PacketStreamerServicer,
     add_PacketStreamerServicer_to_server,
 )
-from .grpc_protobuf.netsim.packet_streamer_pb2 import PacketRequest, PacketResponse
-from .grpc_protobuf.netsim.hci_packet_pb2 import HCIPacket
-from .grpc_protobuf.netsim.startup_pb2 import Chip, ChipInfo, DeviceInfo
-from .grpc_protobuf.netsim.common_pb2 import ChipKind
+from bumble.transport.grpc_protobuf.netsim.packet_streamer_pb2 import (
+    PacketRequest,
+    PacketResponse,
+)
+from bumble.transport.grpc_protobuf.netsim.hci_packet_pb2 import HCIPacket
+from bumble.transport.grpc_protobuf.netsim.startup_pb2 import Chip, ChipInfo, DeviceInfo
+from bumble.transport.grpc_protobuf.netsim.common_pb2 import ChipKind
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/transport/file.py
+++ b/bumble/transport/file.py
@@ -19,7 +19,7 @@ import asyncio
 import io
 import logging
 
-from .common import Transport, StreamPacketSource, StreamPacketSink
+from bumble.transport.common import Transport, StreamPacketSource, StreamPacketSink
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/hci_socket.py
+++ b/bumble/transport/hci_socket.py
@@ -25,7 +25,7 @@ import collections
 
 from typing import Optional
 
-from .common import Transport, ParserSource
+from bumble.transport.common import Transport, ParserSource
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/transport/pty.py
+++ b/bumble/transport/pty.py
@@ -25,7 +25,7 @@ import logging
 
 from typing import Optional
 
-from .common import Transport, StreamPacketSource, StreamPacketSink
+from bumble.transport.common import Transport, StreamPacketSource, StreamPacketSink
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/pyusb.py
+++ b/bumble/transport/pyusb.py
@@ -29,9 +29,9 @@ from usb.core import USBError
 from usb.util import CTRL_TYPE_CLASS, CTRL_RECIPIENT_OTHER
 from usb.legacy import REQ_SET_FEATURE, REQ_CLEAR_FEATURE, CLASS_HUB
 
-from .common import Transport, ParserSource, TransportInitError
-from .. import hci
-from ..colors import color
+from bumble.transport.common import Transport, ParserSource, TransportInitError
+from bumble import hci
+from bumble.colors import color
 
 
 # -----------------------------------------------------------------------------

--- a/bumble/transport/serial.py
+++ b/bumble/transport/serial.py
@@ -19,7 +19,7 @@ import asyncio
 import logging
 import serial_asyncio
 
-from .common import Transport, StreamPacketSource, StreamPacketSink
+from bumble.transport.common import Transport, StreamPacketSource, StreamPacketSink
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/tcp_client.py
+++ b/bumble/transport/tcp_client.py
@@ -18,7 +18,7 @@
 import asyncio
 import logging
 
-from .common import Transport, StreamPacketSource, StreamPacketSink
+from bumble.transport.common import Transport, StreamPacketSource, StreamPacketSink
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/tcp_server.py
+++ b/bumble/transport/tcp_server.py
@@ -20,7 +20,7 @@ import asyncio
 import logging
 import socket
 
-from .common import Transport, StreamPacketSource
+from bumble.transport.common import Transport, StreamPacketSource
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/udp.py
+++ b/bumble/transport/udp.py
@@ -18,7 +18,7 @@
 import asyncio
 import logging
 
-from .common import Transport, ParserSource
+from bumble.transport.common import Transport, ParserSource
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/unix.py
+++ b/bumble/transport/unix.py
@@ -18,7 +18,7 @@
 import asyncio
 import logging
 
-from .common import Transport, StreamPacketSource, StreamPacketSink
+from bumble.transport.common import Transport, StreamPacketSource, StreamPacketSink
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/vhci.py
+++ b/bumble/transport/vhci.py
@@ -19,8 +19,8 @@ import logging
 
 from typing import Optional
 
-from .common import Transport
-from .file import open_file_transport
+from bumble.transport.common import Transport
+from bumble.transport.file import open_file_transport
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/ws_client.py
+++ b/bumble/transport/ws_client.py
@@ -18,7 +18,12 @@
 import logging
 import websockets.client
 
-from .common import PumpedPacketSource, PumpedPacketSink, PumpedTransport, Transport
+from bumble.transport.common import (
+    PumpedPacketSource,
+    PumpedPacketSink,
+    PumpedTransport,
+    Transport,
+)
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/transport/ws_server.py
+++ b/bumble/transport/ws_server.py
@@ -18,7 +18,7 @@
 import logging
 import websockets
 
-from .common import Transport, ParserSource, PumpedPacketSink
+from bumble.transport.common import Transport, ParserSource, PumpedPacketSink
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/bumble/utils.py
+++ b/bumble/utils.py
@@ -40,7 +40,7 @@ from typing_extensions import Self
 
 from pyee import EventEmitter
 
-from .colors import color
+from bumble.colors import color
 
 # -----------------------------------------------------------------------------
 # Logging


### PR DESCRIPTION
PEP-8 and Google Pystyle both suggest to use absolute import instead of relative import.