### PR TITLE
Add omitted parameter for the function of `display_number`.

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -5669,7 +5669,9 @@ class Device(utils.CompositeEventEmitter):
 
         # Show the passkey to the user
         utils.cancel_on_event(
-            connection, 'disconnection', pairing_config.delegate.display_number(passkey)
+            connection,
+            'disconnection',
+            pairing_config.delegate.display_number(passkey, digits=6)
         )
 
     # [Classic only]


### PR DESCRIPTION
For the function of `display_number` in device.py, the second parameter of `digits` is necessary, so assign the value of 6 to `digits` because valid values of passkey are decimal 000000 to 999999.