### PR TITLE
Declare emitted events as constants

### DIFF
--- a/bumble/att.py
+++ b/bumble/att.py
@@ -836,6 +836,9 @@ class Attribute(utils.EventEmitter, Generic[_T]):
     READ_REQUIRES_AUTHORIZATION = Permissions.READ_REQUIRES_AUTHORIZATION
     WRITE_REQUIRES_AUTHORIZATION = Permissions.WRITE_REQUIRES_AUTHORIZATION
 
+    EVENT_READ = "read"
+    EVENT_WRITE = "write"
+
     value: Union[AttributeValue[_T], _T, None]
 
     def __init__(
@@ -906,7 +909,7 @@ class Attribute(utils.EventEmitter, Generic[_T]):
         else:
             value = self.value
 
-        self.emit('read', connection, b'' if value is None else value)
+        self.emit(self.EVENT_READ, connection, b'' if value is None else value)
 
         return b'' if value is None else self.encode_value(value)
 
@@ -947,7 +950,7 @@ class Attribute(utils.EventEmitter, Generic[_T]):
         else:
             self.value = decoded_value
 
-        self.emit('write', connection, decoded_value)
+        self.emit(self.EVENT_WRITE, connection, decoded_value)
 
     def __repr__(self):
         if isinstance(self.value, bytes):

--- a/bumble/avctp.py
+++ b/bumble/avctp.py
@@ -166,8 +166,8 @@ class Protocol:
 
         # Register to receive PDUs from the channel
         l2cap_channel.sink = self.on_pdu
-        l2cap_channel.on("open", self.on_l2cap_channel_open)
-        l2cap_channel.on("close", self.on_l2cap_channel_close)
+        l2cap_channel.on(l2cap_channel.EVENT_OPEN, self.on_l2cap_channel_open)
+        l2cap_channel.on(l2cap_channel.EVENT_CLOSE, self.on_l2cap_channel_close)
 
     def on_l2cap_channel_open(self):
         logger.debug(color("<<< AVCTP channel open", "magenta"))

--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -448,6 +448,8 @@ class Characteristic(Attribute[_T]):
     uuid: UUID
     properties: Characteristic.Properties
 
+    EVENT_SUBSCRIPTION = "subscription"
+
     class Properties(enum.IntFlag):
         """Property flags"""
 

--- a/bumble/gatt_client.py
+++ b/bumble/gatt_client.py
@@ -202,6 +202,8 @@ class CharacteristicProxy(AttributeProxy[_T]):
     descriptors: List[DescriptorProxy]
     subscribers: Dict[Any, Callable[[_T], Any]]
 
+    EVENT_UPDATE = "update"
+
     def __init__(
         self,
         client: Client,
@@ -308,7 +310,7 @@ class Client:
         self.services = []
         self.cached_values = {}
 
-        connection.on('disconnection', self.on_disconnection)
+        connection.on(connection.EVENT_DISCONNECTION, self.on_disconnection)
 
     def send_gatt_pdu(self, pdu: bytes) -> None:
         self.connection.send_l2cap_pdu(ATT_CID, pdu)
@@ -1142,7 +1144,7 @@ class Client:
             if callable(subscriber):
                 subscriber(notification.attribute_value)
             else:
-                subscriber.emit('update', notification.attribute_value)
+                subscriber.emit(subscriber.EVENT_UPDATE, notification.attribute_value)
 
     def on_att_handle_value_indication(self, indication):
         # Call all subscribers
@@ -1157,7 +1159,7 @@ class Client:
             if callable(subscriber):
                 subscriber(indication.attribute_value)
             else:
-                subscriber.emit('update', indication.attribute_value)
+                subscriber.emit(subscriber.EVENT_UPDATE, indication.attribute_value)
 
         # Confirm that we received the indication
         self.send_confirmation(ATT_Handle_Value_Confirmation())

--- a/bumble/gatt_server.py
+++ b/bumble/gatt_server.py
@@ -110,6 +110,8 @@ class Server(utils.EventEmitter):
     indication_semaphores: defaultdict[int, asyncio.Semaphore]
     pending_confirmations: defaultdict[int, Optional[asyncio.futures.Future]]
 
+    EVENT_CHARACTERISTIC_SUBSCRIPTION = "characteristic_subscription"
+
     def __init__(self, device: Device) -> None:
         super().__init__()
         self.device = device
@@ -347,10 +349,13 @@ class Server(utils.EventEmitter):
         notify_enabled = value[0] & 0x01 != 0
         indicate_enabled = value[0] & 0x02 != 0
         characteristic.emit(
-            'subscription', connection, notify_enabled, indicate_enabled
+            characteristic.EVENT_SUBSCRIPTION,
+            connection,
+            notify_enabled,
+            indicate_enabled,
         )
         self.emit(
-            'characteristic_subscription',
+            self.EVENT_CHARACTERISTIC_SUBSCRIPTION,
             connection,
             characteristic,
             notify_enabled,

--- a/bumble/pandora/l2cap.py
+++ b/bumble/pandora/l2cap.py
@@ -83,7 +83,7 @@ class L2CAPService(L2CAPServicer):
             close_future.set_result(None)
 
         l2cap_channel.sink = on_channel_sdu
-        l2cap_channel.on('close', on_close)
+        l2cap_channel.on(l2cap_channel.EVENT_CLOSE, on_close)
 
         return ChannelContext(close_future, sdu_queue)
 
@@ -151,7 +151,7 @@ class L2CAPService(L2CAPServicer):
                 spec=spec, handler=on_l2cap_channel
             )
         else:
-            l2cap_server.on('connection', on_l2cap_channel)
+            l2cap_server.on(l2cap_server.EVENT_CONNECTION, on_l2cap_channel)
 
         try:
             self.log.debug('Waiting for a channel connection.')

--- a/bumble/pandora/security.py
+++ b/bumble/pandora/security.py
@@ -302,15 +302,15 @@ class SecurityService(SecurityServicer):
 
                 with contextlib.closing(bumble.utils.EventWatcher()) as watcher:
 
-                    @watcher.on(connection, 'pairing')
+                    @watcher.on(connection, connection.EVENT_PAIRING)
                     def on_pairing(*_: Any) -> None:
                         security_result.set_result('success')
 
-                    @watcher.on(connection, 'pairing_failure')
+                    @watcher.on(connection, connection.EVENT_PAIRING_FAILURE)
                     def on_pairing_failure(*_: Any) -> None:
                         security_result.set_result('pairing_failure')
 
-                    @watcher.on(connection, 'disconnection')
+                    @watcher.on(connection, connection.EVENT_DISCONNECTION)
                     def on_disconnection(*_: Any) -> None:
                         security_result.set_result('connection_died')
 

--- a/bumble/profiles/ancs.py
+++ b/bumble/profiles/ancs.py
@@ -250,6 +250,8 @@ class AncsClient(utils.EventEmitter):
     _expected_response_tuples: int
     _response_accumulator: bytes
 
+    EVENT_NOTIFICATION = "notification"
+
     def __init__(self, ancs_proxy: AncsProxy) -> None:
         super().__init__()
         self._ancs_proxy = ancs_proxy
@@ -284,7 +286,7 @@ class AncsClient(utils.EventEmitter):
 
     def _on_notification(self, notification: Notification) -> None:
         logger.debug(f"ANCS NOTIFICATION: {notification}")
-        self.emit("notification", notification)
+        self.emit(self.EVENT_NOTIFICATION, notification)
 
     def _on_data(self, data: bytes) -> None:
         logger.debug(f"ANCS DATA: {data.hex()}")

--- a/bumble/profiles/hap.py
+++ b/bumble/profiles/hap.py
@@ -266,13 +266,13 @@ class HearingAccessService(gatt.TemplateService):
         # associate the lowest index as the current active preset at startup
         self.active_preset_index = sorted(self.preset_records.keys())[0]
 
-        @device.on('connection')  # type: ignore
+        @device.on(device.EVENT_CONNECTION)
         def on_connection(connection: Connection) -> None:
-            @connection.on('disconnection')  # type: ignore
+            @connection.on(connection.EVENT_DISCONNECTION)
             def on_disconnection(_reason) -> None:
                 self.currently_connected_clients.remove(connection)
 
-            @connection.on('pairing')  # type: ignore
+            @connection.on(connection.EVENT_PAIRING)
             def on_pairing(*_: Any) -> None:
                 self.on_incoming_paired_connection(connection)
 

--- a/bumble/profiles/mcp.py
+++ b/bumble/profiles/mcp.py
@@ -338,6 +338,12 @@ class MediaControlServiceProxy(
         'content_control_id': gatt.GATT_CONTENT_CONTROL_ID_CHARACTERISTIC,
     }
 
+    EVENT_MEDIA_STATE = "media_state"
+    EVENT_TRACK_CHANGED = "track_changed"
+    EVENT_TRACK_TITLE = "track_title"
+    EVENT_TRACK_DURATION = "track_duration"
+    EVENT_TRACK_POSITION = "track_position"
+
     media_player_name: Optional[gatt_client.CharacteristicProxy[bytes]] = None
     media_player_icon_object_id: Optional[gatt_client.CharacteristicProxy[bytes]] = None
     media_player_icon_url: Optional[gatt_client.CharacteristicProxy[bytes]] = None
@@ -432,20 +438,20 @@ class MediaControlServiceProxy(
         self.media_control_point_notifications.put_nowait(data)
 
     def _on_media_state(self, data: bytes) -> None:
-        self.emit('media_state', MediaState(data[0]))
+        self.emit(self.EVENT_MEDIA_STATE, MediaState(data[0]))
 
     def _on_track_changed(self, data: bytes) -> None:
         del data
-        self.emit('track_changed')
+        self.emit(self.EVENT_TRACK_CHANGED)
 
     def _on_track_title(self, data: bytes) -> None:
-        self.emit('track_title', data.decode("utf-8"))
+        self.emit(self.EVENT_TRACK_TITLE, data.decode("utf-8"))
 
     def _on_track_duration(self, data: bytes) -> None:
-        self.emit('track_duration', struct.unpack_from('<i', data)[0])
+        self.emit(self.EVENT_TRACK_DURATION, struct.unpack_from('<i', data)[0])
 
     def _on_track_position(self, data: bytes) -> None:
-        self.emit('track_position', struct.unpack_from('<i', data)[0])
+        self.emit(self.EVENT_TRACK_POSITION, struct.unpack_from('<i', data)[0])
 
 
 class GenericMediaControlServiceProxy(MediaControlServiceProxy):

--- a/bumble/profiles/vcs.py
+++ b/bumble/profiles/vcs.py
@@ -91,6 +91,8 @@ class VolumeState:
 class VolumeControlService(gatt.TemplateService):
     UUID = gatt.GATT_VOLUME_CONTROL_SERVICE
 
+    EVENT_VOLUME_STATE_CHANGE = "volume_state_change"
+
     volume_state: gatt.Characteristic[bytes]
     volume_control_point: gatt.Characteristic[bytes]
     volume_flags: gatt.Characteristic[bytes]
@@ -166,7 +168,7 @@ class VolumeControlService(gatt.TemplateService):
                 'disconnection',
                 connection.device.notify_subscribers(attribute=self.volume_state),
             )
-            self.emit('volume_state_change')
+            self.emit(self.EVENT_VOLUME_STATE_CHANGE)
 
     def _on_relative_volume_down(self) -> bool:
         old_volume = self.volume_setting

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -724,12 +724,13 @@ class Session:
         self.is_responder = not self.is_initiator
 
         # Listen for connection events
-        connection.on('disconnection', self.on_disconnection)
+        connection.on(connection.EVENT_DISCONNECTION, self.on_disconnection)
         connection.on(
-            'connection_encryption_change', self.on_connection_encryption_change
+            connection.EVENT_CONNECTION_ENCRYPTION_CHANGE,
+            self.on_connection_encryption_change,
         )
         connection.on(
-            'connection_encryption_key_refresh',
+            connection.EVENT_CONNECTION_ENCRYPTION_KEY_REFRESH,
             self.on_connection_encryption_key_refresh,
         )
 
@@ -1310,12 +1311,15 @@ class Session:
         )
 
     def on_disconnection(self, _: int) -> None:
-        self.connection.remove_listener('disconnection', self.on_disconnection)
         self.connection.remove_listener(
-            'connection_encryption_change', self.on_connection_encryption_change
+            self.connection.EVENT_DISCONNECTION, self.on_disconnection
         )
         self.connection.remove_listener(
-            'connection_encryption_key_refresh',
+            self.connection.EVENT_CONNECTION_ENCRYPTION_CHANGE,
+            self.on_connection_encryption_change,
+        )
+        self.connection.remove_listener(
+            self.connection.EVENT_CONNECTION_ENCRYPTION_KEY_REFRESH,
             self.on_connection_encryption_key_refresh,
         )
         self.manager.on_session_end(self)
@@ -1962,7 +1966,7 @@ class Manager(utils.EventEmitter):
     def on_smp_security_request_command(
         self, connection: Connection, request: SMP_Security_Request_Command
     ) -> None:
-        connection.emit('security_request', request.auth_req)
+        connection.emit(connection.EVENT_SECURITY_REQUEST, request.auth_req)
 
     def on_smp_pdu(self, connection: Connection, pdu: bytes) -> None:
         # Parse the L2CAP payload into an SMP Command object


### PR DESCRIPTION
Emitting and listening to literal events are dangerous because:
1. When event name changes, type checker cannot capture the error
2. Some long event names could be typo

So we should make them constants.

This PR also typified and corrected some AVDTP functions.

For host, since current composite listeners relies on the event name, we may change it in another PR.