### PR TITLE
fix a few timescale adjustments

### DIFF
--- a/apps/bench.py
+++ b/apps/bench.py
@@ -121,9 +121,9 @@ def print_connection(connection):
 
         params.append(
             'Parameters='
-            f'{connection.parameters.connection_interval * 1.25:.2f}/'
+            f'{connection.parameters.connection_interval:.2f}/'
             f'{connection.parameters.peripheral_latency}/'
-            f'{connection.parameters.supervision_timeout * 10} '
+            f'{connection.parameters.supervision_timeout:.2f} '
         )
 
         params.append(f'MTU={connection.att_mtu}')

--- a/apps/console.py
+++ b/apps/console.py
@@ -335,9 +335,9 @@ class ConsoleApp:
             elif self.connected_peer:
                 connection = self.connected_peer.connection
                 connection_parameters = (
-                    f'{connection.parameters.connection_interval}/'
+                    f'{connection.parameters.connection_interval:.2f}/'
                     f'{connection.parameters.peripheral_latency}/'
-                    f'{connection.parameters.supervision_timeout}'
+                    f'{connection.parameters.supervision_timeout:.2f}'
                 )
                 if self.connection_phy is not None:
                     phy_state = (

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -5976,6 +5976,33 @@ class HCI_LE_Enhanced_Connection_Complete_Event(HCI_LE_Meta_Event):
     [
         ('status', STATUS_SPEC),
         ('connection_handle', 2),
+        (
+            'role',
+            {'size': 1, 'mapper': lambda x: 'CENTRAL' if x == 0 else 'PERIPHERAL'},
+        ),
+        ('peer_address_type', Address.ADDRESS_TYPE_SPEC),
+        ('peer_address', Address.parse_address_preceded_by_type),
+        ('local_resolvable_private_address', Address.parse_random_address),
+        ('peer_resolvable_private_address', Address.parse_random_address),
+        ('connection_interval', 2),
+        ('peripheral_latency', 2),
+        ('supervision_timeout', 2),
+        ('central_clock_accuracy', 1),
+        ('advertising_handle', 1),
+        ('sync_handle', 2),
+    ]
+)
+class HCI_LE_Enhanced_Connection_Complete_V2_Event(HCI_LE_Meta_Event):
+    '''
+    See Bluetooth spec @ 7.7.65.10 LE Enhanced Connection Complete Event
+    '''
+
+
+# -----------------------------------------------------------------------------
+@HCI_LE_Meta_Event.event(
+    [
+        ('status', STATUS_SPEC),
+        ('connection_handle', 2),
         ('tx_phy', {'size': 1, 'mapper': HCI_Constant.le_phy_name}),
         ('rx_phy', {'size': 1, 'mapper': HCI_Constant.le_phy_name}),
     ]

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -456,6 +456,7 @@ class Host(utils.EventEmitter):
                     hci.HCI_LE_READ_LOCAL_P_256_PUBLIC_KEY_COMPLETE_EVENT,
                     hci.HCI_LE_GENERATE_DHKEY_COMPLETE_EVENT,
                     hci.HCI_LE_ENHANCED_CONNECTION_COMPLETE_EVENT,
+                    hci.HCI_LE_ENHANCED_CONNECTION_COMPLETE_V2_EVENT,
                     hci.HCI_LE_DIRECTED_ADVERTISING_REPORT_EVENT,
                     hci.HCI_LE_PHY_UPDATE_COMPLETE_EVENT,
                     hci.HCI_LE_EXTENDED_ADVERTISING_REPORT_EVENT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "prompt_toolkit >= 3.0.16; platform_system!='Emscripten'",
     "prettytable >= 3.6.0; platform_system!='Emscripten'",
     "protobuf >= 3.12.4; platform_system!='Emscripten'",
-    "pyee >= 8.2.2",
+    "pyee >= 13.0.0",
     "pyserial-asyncio >= 0.5; platform_system!='Emscripten'",
     "pyserial >= 3.5; platform_system!='Emscripten'",
     "pyusb >= 1.2; platform_system!='Emscripten'",


### PR DESCRIPTION
There were still a few places where the timescales were not properly converted between the internal (HCI) level and the external (Device API) level.
The basic rule is that at the "user" level, the Device API should always try to hide some of the low-level details, including some the HCI-level timescales (where some time values are expressed, for example, in units of 1.25ms or 0.625ms).
This means that data structure and parameters at the `host.py` level (including parameters for events emitted by the `Host` object) use the low level HCI timescales, whereas public data structures and parameters at the `device.py` level use higher level "natural" units (seconds, milliseconds, ...).

This change also includes support for `HCI_LE_Enhanced_Connection_Complete_V2_Event` which was missing.