### PR TITLE
cryptography: bump version to 44.0.3 to fix python parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ dependencies = [
     "aiohttp ~= 3.8; platform_system!='Emscripten'",
     "appdirs >= 1.4; platform_system!='Emscripten'",
     "click >= 8.1.3; platform_system!='Emscripten'",
-    "cryptography >= 39; platform_system!='Emscripten'",
+    "cryptography >= 44.0.3; platform_system!='Emscripten'",
     # Pyodide bundles a version of cryptography that is built for wasm, which may not match the
     # versions available on PyPI. Relax the version requirement since it's better than being
     # completely unable to import the package in case of version mismatch.
-    "cryptography >= 39.0; platform_system=='Emscripten'",
+    "cryptography >= 44.0.3; platform_system=='Emscripten'",
     "grpcio >= 1.62.1; platform_system!='Emscripten'",
     "humanize >= 4.6.0; platform_system!='Emscripten'",
     "libusb1 >= 2.0.1; platform_system!='Emscripten'",


### PR DESCRIPTION
Bug: 404336381
