### PR TITLE
HCI: Avoid patching __init__

### DIFF
--- a/bumble/controller.py
+++ b/bumble/controller.py
@@ -108,7 +108,9 @@ class Connection:
     def on_hci_acl_data_packet(self, packet):
         self.assembler.feed_packet(packet)
         self.controller.send_hci_packet(
-            HCI_Number_Of_Completed_Packets_Event([(self.handle, 1)])
+            HCI_Number_Of_Completed_Packets_Event(
+                connection_handles=[self.handle], num_completed_packets=[1]
+            )
         )
 
     def on_acl_pdu(self, data):

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -1519,13 +1519,15 @@ class Host(utils.EventEmitter):
         self.emit('inquiry_complete')
 
     def on_hci_inquiry_result_with_rssi_event(self, event):
-        for response in event.responses:
+        for bd_addr, class_of_device, rssi in zip(
+            event.bd_addr, event.class_of_device, event.rssi
+        ):
             self.emit(
                 'inquiry_result',
-                response.bd_addr,
-                response.class_of_device,
+                bd_addr,
+                class_of_device,
                 b'',
-                response.rssi,
+                rssi,
             )
 
     def on_hci_extended_inquiry_result_event(self, event):


### PR DESCRIPTION
op_code is usually set to class (not instance) inside decorators, and passing it to __init__ is not a common scenario, so here we change the order of __init__ to force it a keyword argument.

Also replace some legacy `registered` commands with listed fields.