### PR TITLE
Dataclass-based ASCS Packets

### DIFF
--- a/tests/bap_test.py
+++ b/tests/bap_test.py
@@ -431,12 +431,7 @@ async def test_ascs():
     )
 
     # Release
-    await ascs_client.ase_control_point.write_value(
-        ASE_Release(
-            ase_id=[1, 2],
-            metadata=[b'foo', b'bar'],
-        )
-    )
+    await ascs_client.ase_control_point.write_value(ASE_Release(ase_id=[1, 2]))
     assert (await notifications[1].get())[:2] == bytes(
         [1, AseStateMachine.State.RELEASING]
     )


### PR DESCRIPTION
This has been used in [Navi](https://github.com/google/bt-navi-tests/blob/main/navi/bumble_ext/hci.py) for a while. Recently I resolved several critical issues and I think it's a time to bring it into Bumble upstream.

An obvious benefit to use dataclasses is IDE and type checker integration. 

<img width="615" alt="image" src="https://github.com/user-attachments/assets/33f11243-5c45-4047-a753-e48cfbe834e6" />


Unlike https://github.com/google/bumble/pull/430, this design properly utilize the existing effort, especially field specs. For nested fields, we may need to set another field in metadata like `Annotated[list, 1, '[' or ']' ]` as stack operator, though usually we only support up to 2 layers.

return_parameters_fields cannot be benifit from this, because current type checker cannot associate two classes. But BTW, return_parameters_fields is actually not necessary to be inside decorator, so later we may have a PR to move them from decorators to classes.