### PR TITLE
Fix wrong remove iso data path parameter

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1464,7 +1464,7 @@ class _IsoLink:
             check_result=True,
         )
 
-    async def remove_data_path(self, direction: _IsoLink.Direction) -> int:
+    async def remove_data_path(self, directions: Iterable[_IsoLink.Direction]) -> int:
         """Remove a data path with controller on given direction.
 
         Args:
@@ -1476,7 +1476,9 @@ class _IsoLink:
         response = await self.device.send_command(
             hci.HCI_LE_Remove_ISO_Data_Path_Command(
                 connection_handle=self.handle,
-                data_path_direction=direction,
+                data_path_direction=sum(
+                    1 << direction for direction in set(directions)
+                ),
             ),
             check_result=False,
         )

--- a/bumble/profiles/ascs.py
+++ b/bumble/profiles/ascs.py
@@ -516,7 +516,7 @@ class AseStateMachine(gatt.Characteristic):
 
         async def remove_cis_async():
             if self.cis_link:
-                await self.cis_link.remove_data_path(self.role)
+                await self.cis_link.remove_data_path([self.role])
             self.state = self.State.IDLE
             await self.service.device.notify_subscribers(self, self.value)
 


### PR DESCRIPTION
Unlike `HCI_LE_Setup_ISO_Data_Path_Command`, `HCI_LE_Remove_ISO_Data_Path_Command` takes a flag parameter instead of an enum parameter.