### PR TITLE
speaker app: enable opus, enable more options

### DIFF
--- a/apps/speaker/speaker.html
+++ b/apps/speaker/speaker.html
@@ -15,6 +15,7 @@
           <tr><td>Codec</td><td><span id="codecText"></span></td></tr>
           <tr><td>Packets</td><td><span id="packetsReceivedText"></span></td></tr>
           <tr><td>Bytes</td><td><span id="bytesReceivedText"></span></td></tr>
+          <tr><td>Bitrate</td><td><span id="bitrate"></span></td></tr>
         </table>
       </td>
       <td>

--- a/bumble/a2dp.py
+++ b/bumble/a2dp.py
@@ -479,6 +479,14 @@ class OpusMediaCodecInformation(VendorSpecificMediaCodecInformation):
     class SamplingFrequency(enum.IntFlag):
         SF_48000 = 1 << 0
 
+        @classmethod
+        def from_int(
+            cls, sampling_frequency: int
+        ) -> OpusMediaCodecInformation.SamplingFrequency:
+            if sampling_frequency != 48000:
+                raise ValueError("no such sampling frequency")
+            return cls.SF_48000
+
     VENDOR_ID: ClassVar[int] = 0x000000E0
     CODEC_ID: ClassVar[int] = 0x0001
 


### PR DESCRIPTION
Adding support for Opus playback. Should work in Chrome (not tested on other browsers).
This shifts from using MSE, which isn't very good for low latency, to using WebAudio and WebCodecs, which gives us a much better latency, and supports both AAC and Opus streams.
This PR also includes a few command line options to allow controlling which bitrates and sampling frequencies are advertised. 
Also added to the UI: display the current bitrate (averaged over the last ~30 buffers).