### PR TITLE
hotfix

### DIFF
--- a/bumble/a2dp.py
+++ b/bumble/a2dp.py
@@ -480,12 +480,10 @@ class OpusMediaCodecInformation(VendorSpecificMediaCodecInformation):
         SF_48000 = 1 << 0
 
         @classmethod
-        def from_int(
-            cls, sampling_frequency: int
-        ) -> OpusMediaCodecInformation.SamplingFrequency:
+        def from_int(cls, sampling_frequency: int) -> Self:
             if sampling_frequency != 48000:
                 raise ValueError("no such sampling frequency")
-            return cls.SF_48000
+            return cls(1)
 
     VENDOR_ID: ClassVar[int] = 0x000000E0
     CODEC_ID: ClassVar[int] = 0x0001


### PR DESCRIPTION
Somehow at runtime, python 3.9 could not find the `from_int` class method. No time to investigate, this will fix the issue simply.