### PR TITLE
fix legacy pairing with oob

### DIFF
--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -762,7 +762,9 @@ class Session:
 
         # OOB
         self.oob_data_flag = (
-            1 if pairing_config.oob and pairing_config.oob.peer_data else 0
+            1
+            if pairing_config.oob and (not self.sc or pairing_config.oob.peer_data)
+            else 0
         )
 
         # Set up addresses


### PR DESCRIPTION
This addresses the issue reported in #713 
For OOB pairing with legacy pairing, peer data is only needed by one side, even if both should set the oob_data flag.