### PR TITLE
fix: add missing metadata call for `peer_identity_address_type` in `HCI_LE_Set_Privacy_Mode_Command`

### DIFF
--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -4990,7 +4990,9 @@ class HCI_LE_Set_Privacy_Mode_Command(HCI_Command):
         NETWORK_PRIVACY_MODE = 0x00
         DEVICE_PRIVACY_MODE = 0x01
 
-    peer_identity_address_type: int = field(metadata=Address.ADDRESS_TYPE_SPEC)
+    peer_identity_address_type: int = field(
+        metadata=metadata(Address.ADDRESS_TYPE_SPEC)
+    )
     peer_identity_address: Address = field(
         metadata=metadata(Address.parse_address_preceded_by_type)
     )


### PR DESCRIPTION
While handling the `HCI_LE_Set_Privacy_Mode_Command`, a recurring exception is observed:
<img width="1700" height="418" alt="image" src="https://github.com/user-attachments/assets/bf1794c7-de7a-4020-9eae-67f0b70f593a" />

Missing metadata for `peer_identity_address_type` in `HCI_LE_Set_Privacy_Mode_Command` - no `bumble.hci` tag, which causes exceptions during command handling.