### PR TITLE
Allow register HCI packets with custom names

### DIFF
--- a/tests/hci_test.py
+++ b/tests/hci_test.py
@@ -238,6 +238,15 @@ def test_HCI_Command():
     command = hci.HCI_Command(op_code=0x5566, parameters=bytes.fromhex('AABBCC'))
     basic_check(command)
 
+    @hci.HCI_Command.command
+    class CustomCommand(hci.HCI_Command):
+        op_code = 0x7788
+        name = 'Custom Command'
+
+    basic_check(CustomCommand())
+    assert CustomCommand().op_code == 0x7788
+    assert CustomCommand().name == 'Custom Command'
+
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(

--- a/tests/hci_test.py
+++ b/tests/hci_test.py
@@ -238,14 +238,50 @@ def test_HCI_Command():
     command = hci.HCI_Command(op_code=0x5566, parameters=bytes.fromhex('AABBCC'))
     basic_check(command)
 
+
+# -----------------------------------------------------------------------------
+def test_custom_command():
     @hci.HCI_Command.command
     class CustomCommand(hci.HCI_Command):
         op_code = 0x7788
         name = 'Custom Command'
 
-    basic_check(CustomCommand())
-    assert CustomCommand().op_code == 0x7788
-    assert CustomCommand().name == 'Custom Command'
+    command = CustomCommand()
+    basic_check(command)
+    parsed = hci.HCI_Packet.from_bytes(bytes(command))
+    assert isinstance(parsed, CustomCommand)
+    assert parsed.op_code == 0x7788
+    assert parsed.name == 'Custom Command'
+
+
+# -----------------------------------------------------------------------------
+def test_custom_event():
+    @hci.HCI_Event.event
+    class CustomEvent(hci.HCI_Event):
+        event_code = 0x99
+        name = 'Custom Event'
+
+    event = CustomEvent()
+    basic_check(event)
+    parsed = hci.HCI_Packet.from_bytes(bytes(event))
+    assert isinstance(parsed, CustomEvent)
+    assert parsed.event_code == 0x99
+    assert parsed.name == 'Custom Event'
+
+
+# -----------------------------------------------------------------------------
+def test_custom_le_meta_event():
+    @hci.HCI_LE_Meta_Event.event
+    class CustomEvent(hci.HCI_LE_Meta_Event):
+        subevent_code = 0xFF
+        name = 'Custom Extended Event'
+
+    event = CustomEvent()
+    basic_check(event)
+    parsed = hci.HCI_Packet.from_bytes(bytes(event))
+    assert isinstance(parsed, CustomEvent)
+    assert parsed.subevent_code == 0xFF
+    assert parsed.name == 'Custom Extended Event'
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The original solution to register a packet class is little bit complicated, like:
1. (If opcode or event code is not registered yet) define a HCI* constants and call register function
2. Define packet classes with a hybrid case of name, which is usually considered incompliant by linters

The new approach allows classes declares these parameters as members.