### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "bumble"
 dynamic = ["version"]
 description = "Bluetooth Stack for Apps, Emulation, Test and Experimentation"
 readme = "README.md"
+license = "Apache-2.0"
 authors = [{ name = "Google", email = "bumble-dev@google.com" }]
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
This changes the license field to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API and is used by downstream tools including deps.dev

These changes were generated by Claude (sorry it wasn't Gemini) after reviewing the license and manifest files in your repository, but opened and reviewed by me. Please let me know if the analysis is incorrect and thanks for being an OSS maintainer.