### PR TITLE
update to black 25.1

### DIFF
--- a/bumble/avrcp.py
+++ b/bumble/avrcp.py
@@ -1117,7 +1117,7 @@ class Protocol(utils.EventEmitter):
 
     @staticmethod
     def _check_vendor_dependent_frame(
-        frame: Union[avc.VendorDependentCommandFrame, avc.VendorDependentResponseFrame]
+        frame: Union[avc.VendorDependentCommandFrame, avc.VendorDependentResponseFrame],
     ) -> bool:
         if frame.company_id != AVRCP_BLUETOOTH_SIG_COMPANY_ID:
             logger.debug("unsupported company id, ignoring")

--- a/bumble/pandora/__init__.py
+++ b/bumble/pandora/__init__.py
@@ -49,7 +49,7 @@ _SERVICERS_HOOKS: list[Callable[[PandoraDevice, Config, grpc.aio.Server], None]]
 
 
 def register_servicer_hook(
-    hook: Callable[[PandoraDevice, Config, grpc.aio.Server], None]
+    hook: Callable[[PandoraDevice, Config, grpc.aio.Server], None],
 ) -> None:
     _SERVICERS_HOOKS.append(hook)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ test = [
     "coverage >= 6.4",
 ]
 development = [
-    "black == 24.3",
+    "black ~= 25.1",
     "bt-test-interfaces >= 0.0.6",
     "grpcio-tools >= 1.62.1",
     "invoke >= 1.7.3",

--- a/tests/hfp_test.py
+++ b/tests/hfp_test.py
@@ -237,7 +237,7 @@ async def test_hf_indicator(hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtoco
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_codec_negotiation(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
 
@@ -281,7 +281,7 @@ async def test_answer(hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]):
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_reject_incoming_call(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
 
@@ -307,7 +307,7 @@ async def test_terminate_call(hfp_connections: tuple[hfp.HfProtocol, hfp.AgProto
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_query_calls_without_calls(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
 
@@ -317,7 +317,7 @@ async def test_query_calls_without_calls(
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_query_calls_with_calls(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
     ag.calls.append(
@@ -418,7 +418,7 @@ async def test_speaker_volume(hfp_connections: tuple[hfp.HfProtocol, hfp.AgProto
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_microphone_volume(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
     microphone_volume_future = asyncio.get_running_loop().create_future()
@@ -448,7 +448,7 @@ async def test_cli_notification(hfp_connections: tuple[hfp.HfProtocol, hfp.AgPro
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_voice_recognition_from_hf(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
     voice_recognition_future = asyncio.get_running_loop().create_future()
@@ -462,7 +462,7 @@ async def test_voice_recognition_from_hf(
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_voice_recognition_from_ag(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
     voice_recognition_future = asyncio.get_running_loop().create_future()
@@ -572,7 +572,7 @@ async def test_sco_setup():
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_hf_batched_response(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
 
@@ -584,7 +584,7 @@ async def test_hf_batched_response(
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_ag_batched_commands(
-    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol]
+    hfp_connections: tuple[hfp.HfProtocol, hfp.AgProtocol],
 ):
     hf, ag = hfp_connections
 


### PR DESCRIPTION
Recent versions of vscode require black >= 25.1 for the python formatter.