### PR TITLE
Upgrade Rust to 1.80.0

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        rust-version: [ "1.76.0", "stable" ]
+        rust-version: [ "1.80.0", "stable" ]
       fail-fast: false
     steps:
       - name: Check out from Git
@@ -72,7 +72,7 @@ jobs:
       - name: Check License Headers
         run: cd rust && cargo run --features dev-tools --bin file-header check-all
       - name: Rust Build
-        run: cd rust && cargo build --all-targets && cargo build-all-features --all-targets
+        run: cd rust && cargo build --all-targets && cargo build-all-features
       # Lints after build so what clippy needs is already built
       - name: Rust Lints
         run: cd rust && cargo fmt --check && cargo clippy --all-targets -- --deny warnings && cargo clippy --all-features --all-targets -- --deny warnings

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/crate/bumble"
 authors = ["Marshall Pierce <marshallpierce@google.com>"]
 keywords = ["bluetooth", "ble"]
 categories = ["api-bindings", "network-programming"]
-rust-version = "1.76.0"
+rust-version = "1.80.0"
 
 # https://github.com/frewsxcv/cargo-all-features#options
 [package.metadata.cargo-all-features]


### PR DESCRIPTION
package `rayon-core v1.13.0` cannot be built because it requires rustc 1.80 or newer, while the currently active rustc version is 1.76.0.