### PR TITLE
enhance serial port transport

### DIFF
--- a/bumble/host.py
+++ b/bumble/host.py
@@ -550,7 +550,7 @@ class Host(utils.EventEmitter):
             logger.debug(
                 'HCI LE flow control: '
                 f'le_acl_data_packet_length={le_acl_data_packet_length},'
-                f'total_num_le_acl_data_packets={total_num_le_acl_data_packets}'
+                f'total_num_le_acl_data_packets={total_num_le_acl_data_packets},'
                 f'iso_data_packet_length={iso_data_packet_length},'
                 f'total_num_iso_data_packets={total_num_iso_data_packets}'
             )

--- a/bumble/transport/android_netsim.py
+++ b/bumble/transport/android_netsim.py
@@ -131,7 +131,11 @@ def publish_grpc_port(grpc_port: int, instance_number: int) -> bool:
 
         def cleanup():
             logger.debug("removing .ini file")
-            ini_file.unlink()
+            try:
+                ini_file.unlink()
+            except OSError as error:
+                # Don't log at exception level, since this may happen normally.
+                logger.debug(f'failed to remove .ini file ({error})')
 
         atexit.register(cleanup)
         return True

--- a/bumble/transport/serial.py
+++ b/bumble/transport/serial.py
@@ -17,6 +17,7 @@
 # -----------------------------------------------------------------------------
 import asyncio
 import logging
+from typing import Optional
 
 import serial_asyncio
 
@@ -51,7 +52,7 @@ class SerialPacketSource(StreamPacketSource):
         logger.debug('connection made')
         self._ready.set()
 
-    def connection_lost(self, exc: Exception | None) -> None:
+    def connection_lost(self, exc: Optional[Exception]) -> None:
         logger.debug('connection lost')
         self.on_transport_lost()
 

--- a/bumble/transport/serial.py
+++ b/bumble/transport/serial.py
@@ -29,24 +29,55 @@ logger = logging.getLogger(__name__)
 
 
 # -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+DEFAULT_POST_OPEN_DELAY = 0.5  # in seconds
+
+# -----------------------------------------------------------------------------
+# Classes and Functions
+# -----------------------------------------------------------------------------
+
+
+# -----------------------------------------------------------------------------
+class SerialPacketSource(StreamPacketSource):
+    def __init__(self) -> None:
+        super().__init__()
+        self._ready = asyncio.Event()
+
+    async def wait_until_ready(self) -> None:
+        await self._ready.wait()
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        logger.debug('connection made')
+        self._ready.set()
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        logger.debug('connection lost')
+        self.on_transport_lost()
+
+
+# -----------------------------------------------------------------------------
 async def open_serial_transport(spec: str) -> Transport:
     '''
     Open a serial port transport.
     The parameter string has this syntax:
-    <device-path>[,<speed>][,rtscts][,dsrdtr]
+    <device-path>[,<speed>][,rtscts][,dsrdtr][,delay]
     When <speed> is omitted, the default value of 1000000 is used
     When "rtscts" is specified, RTS/CTS hardware flow control is enabled
     When "dsrdtr" is specified, DSR/DTR hardware flow control is enabled
+    When "delay" is specified, a short delay is added after opening the port
 
     Examples:
     /dev/tty.usbmodem0006839912172
     /dev/tty.usbmodem0006839912172,1000000
     /dev/tty.usbmodem0006839912172,rtscts
+    /dev/tty.usbmodem0006839912172,rtscts,delay
     '''
 
     speed = 1000000
     rtscts = False
     dsrdtr = False
+    delay = 0.0
     if ',' in spec:
         parts = spec.split(',')
         device = parts[0]
@@ -55,18 +86,40 @@ async def open_serial_transport(spec: str) -> Transport:
                 rtscts = True
             elif part == 'dsrdtr':
                 dsrdtr = True
+            elif part == 'delay':
+                delay = DEFAULT_POST_OPEN_DELAY
             elif part.isnumeric():
                 speed = int(part)
     else:
         device = spec
+
     serial_transport, packet_source = await serial_asyncio.create_serial_connection(
         asyncio.get_running_loop(),
-        StreamPacketSource,
+        SerialPacketSource,
         device,
         baudrate=speed,
         rtscts=rtscts,
         dsrdtr=dsrdtr,
     )
     packet_sink = StreamPacketSink(serial_transport)
+
+    logger.debug('waiting for the port to be ready')
+    await packet_source.wait_until_ready()
+    logger.debug('port is ready')
+
+    # Try to assert DTR
+    assert serial_transport.serial is not None
+    try:
+        serial_transport.serial.dtr = True
+        logger.debug(
+            f"DSR={serial_transport.serial.dsr}, DTR={serial_transport.serial.dtr}"
+        )
+    except Exception as e:
+        logger.warning(f'could not assert DTR: {e}')
+
+    # Wait a bit after opening the port, if requested
+    if delay > 0.0:
+        logger.debug(f'waiting {delay} seconds after opening the port')
+        await asyncio.sleep(delay)
 
     return Transport(packet_source, packet_sink)

--- a/docs/mkdocs/src/transports/serial.md
+++ b/docs/mkdocs/src/transports/serial.md
@@ -4,9 +4,18 @@ SERIAL TRANSPORT
 The serial transport implements sending/receiving HCI packets over a UART (a.k.a serial port).
 
 ## Moniker
-The moniker syntax for a serial transport is: `serial:<device-path>[,<speed>]`
-When `<speed>` is omitted, the default value of 1000000 is used
+The moniker syntax for a serial transport is:  
+    `<device-path>[,<speed>][,rtscts][,dsrdtr][,delay]`
+
+When `<speed>` is omitted, the default value of 1000000 is used.  
+When `rtscts` is specified, RTS/CTS hardware flow control is enabled.  
+When `dsrdtr` is specified, DSR/DTR hardware flow control is enabled.  
+When `delay` is specified, a short delay is added after opening the port.  
 
 !!! example
-    `serial:/dev/tty.usbmodem0006839912172,1000000`
-    Opens the serial port `/dev/tty.usbmodem0006839912172` at `1000000`bps
+    ```
+    /dev/tty.usbmodem0006839912172
+    /dev/tty.usbmodem0006839912172,1000000
+    /dev/tty.usbmodem0006839912172,rtscts
+    /dev/tty.usbmodem0006839912172,rtscts,delay
+    ```


### PR DESCRIPTION
This adds an option to introduce a short delay after opening a serial port (can be useful for HW that has a setup time, like the Nordic HW flow control auto-detect).
