### PR TITLE
Fix - Allow re-creation of CIS link when not successfull

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -4743,7 +4743,7 @@ class Device(utils.CompositeEventEmitter):
             }
 
             def on_cis_establishment(cis_link: CisLink) -> None:
-                self._pending_cis.pop(cis_handle)
+                self._pending_cis.pop(cis_link.handle)
                 if pending_future := pending_cis_establishments.get(cis_link.handle):
                     pending_future.set_result(cis_link)
 

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -4727,7 +4727,7 @@ class Device(utils.CompositeEventEmitter):
         self, cis_acl_pairs: Sequence[tuple[int, Connection]]
     ) -> list[CisLink]:
         for cis_handle, acl_connection in cis_acl_pairs:
-            cis_id, cig_id = self._pending_cis.pop(cis_handle)
+            cis_id, cig_id = self._pending_cis.get(cis_handle)
             self.cis_links[cis_handle] = CisLink(
                 device=self,
                 acl_connection=acl_connection,
@@ -4743,6 +4743,7 @@ class Device(utils.CompositeEventEmitter):
             }
 
             def on_cis_establishment(cis_link: CisLink) -> None:
+                self._pending_cis.pop(cis_handle)
                 if pending_future := pending_cis_establishments.get(cis_link.handle):
                     pending_future.set_result(cis_link)
 


### PR DESCRIPTION
CIS establishment to an _Acceptor_ does not always succeed, as the _Acceptor_ may not respond to CIS Data PDUs after _LL_CIS_IND_ sent. According to spec connection is considered _not-established_ when the Acceptor does respond within 6 consecutive CIS Data PDUs).

To allow re-creation of a CIS link the cis handle is only popped from `_pending_cis` dict once a connection is successfully established.