### PR TITLE
Fixed bug where it's possible for rfcomm tx_credit to go negative resulting in l2cap disconnect from peripheral

### DIFF
--- a/bumble/rfcomm.py
+++ b/bumble/rfcomm.py
@@ -671,15 +671,17 @@ class DLC(utils.EventEmitter):
     def process_tx(self) -> None:
         # Send anything we can (or an empty frame if we need to send rx credits)
         rx_credits_needed = self.rx_credits_needed()
-        while (self.tx_buffer and self.tx_credits > 0) or (
-            rx_credits_needed > 0 and self.tx_credit > 0
-        ):
+        while (self.tx_buffer and self.tx_credits > 0) or rx_credits_needed > 0:
             # Get the next chunk, up to MTU size
             if rx_credits_needed > 0:
-                chunk = bytes([rx_credits_needed]) + self.tx_buffer[: self.mtu - 1]
-                self.tx_buffer = self.tx_buffer[len(chunk) - 1 :]
+                chunk = bytes([rx_credits_needed])
                 self.rx_credits += rx_credits_needed
-                tx_credit_spent = len(chunk) > 1
+                if self.tx_buffer and self.tx_credits > 0:
+                    chunk += self.tx_buffer[: self.mtu - 1]
+                    self.tx_buffer = self.tx_buffer[len(chunk) - 1 :]
+                    tx_credit_spent = True
+                else:
+                    tx_credit_spent = False
             else:
                 chunk = self.tx_buffer[: self.mtu]
                 self.tx_buffer = self.tx_buffer[len(chunk) :]


### PR DESCRIPTION
While conducting large data transfers over rfcomm I found our device would disconnect after 3-400kb. Looking deeper I found it was possible for the tx credit to go negative which is what was causing the l2cap connection to be disconnected by the other device as this violates the standard. 

see attached HCI log
[bumble-rfcomm-hci-negative-tx-credit.txt](https://github.com/user-attachments/files/23108172/bumble-rfcomm-hci-negative-tx-credit.txt)
