### PR TITLE
AVRCP: Reply ACCEPTED on set absolute volume

### DIFF
--- a/bumble/avrcp.py
+++ b/bumble/avrcp.py
@@ -2391,7 +2391,7 @@ class Protocol(utils.EventEmitter):
             effective_volume = await self.delegate.get_absolute_volume()
             self.send_avrcp_response(
                 transaction_label,
-                avc.ResponseFrame.ResponseCode.IMPLEMENTED_OR_STABLE,
+                avc.ResponseFrame.ResponseCode.ACCEPTED,
                 SetAbsoluteVolumeResponse(effective_volume),
             )
 


### PR DESCRIPTION
According to [AV/C spec](https://btprodspecificationrefs.blob.core.windows.net/ext-ref/1394ta/AVC%20Digital%20Interface%20Command%20Set%20%E2%80%93%20General%20Specification,%20Version%204.0,%20Document%20No%201999026.PDF) 7.3.3, CONTROL command should get response code of one of `NOT_IMPLEMENTED`, `ACCEPTED`, `REJECTED`, or `INTERIM`.