### PR TITLE
feat: update default descriptor to default char permissions

### DIFF
--- a/bumble/gatt_server.py
+++ b/bumble/gatt_server.py
@@ -255,7 +255,7 @@ class Server(utils.EventEmitter):
                     # pylint: disable=line-too-long
                     Descriptor(
                         GATT_CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR,
-                        att.Attribute.READABLE | att.Attribute.WRITEABLE,
+                        characteristic.permissions,
                         CharacteristicValue(
                             read=lambda connection, characteristic=characteristic: self.read_cccd(
                                 connection, characteristic


### PR DESCRIPTION
When no descriptor is provided, a default one is created.
It feel strange that this one doesn't have the default permissions of his characteristic.

This could be a nice improvement to avoid overriding the descriptor in the case the char need encryption or authentication for example