### PR TITLE
Cancel l2cap connection result future on abort

### DIFF
--- a/bumble/l2cap.py
+++ b/bumble/l2cap.py
@@ -1149,6 +1149,9 @@ class LeCreditBasedChannel(utils.EventEmitter):
     def abort(self) -> None:
         if self.state == self.State.CONNECTED:
             self._change_state(self.State.DISCONNECTED)
+        if self.state == self.State.CONNECTING:
+            if self.connection_result is not None:
+                self.connection_result.cancel()
 
     def on_pdu(self, pdu: bytes) -> None:
         if self.sink is None:


### PR DESCRIPTION
This cancels the `connection_result` future of LeCreditBasedChannel when abort() is called, e.g. if the LE connection disconnects. This makes it possible for code waiting for a connection to open to detect that the connection has failed.

Fixes google/bumble#825