### PR TITLE
Rust: Fix cargo-all-features to 1.11.0

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -69,7 +69,7 @@ jobs:
           components: clippy,rustfmt
           toolchain: ${{ matrix.rust-version }}
       - name: Install Rust dependencies
-        run: cargo install cargo-all-features # allows building/testing combinations of features
+        run: cargo install cargo-all-features --version 1.11.0  # allows building/testing combinations of features
       - name: Check License Headers
         run: cd rust && cargo run --features dev-tools --bin file-header check-all
       - name: Rust Build


### PR DESCRIPTION
Rust build on 1.80.0 fails with

```c
error[E0599]: no method named `is_multiple_of` found for type `usize` in the current scope
Error:    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-all-features-1.12.0/src/lib.rs:148:26
    |
148 |     if !work_items.len().is_multiple_of(cli.n_chunks) {
    |                          ^^^^^^^^^^^^^^
    |
help: there is a method `next_multiple_of` with a similar name
    |
148 |     if !work_items.len().next_multiple_of(cli.n_chunks) {
    |                          ~~~~~~~~~~~~~~~~

For more information about this error, try `rustc --explain E0599`.
error: could not compile `cargo-all-features` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `cargo-all-features v1.12.0`, intermediate artifacts can be found at `/tmp/cargo-installoi7yF9`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
Error: Process completed with exit code 101.
```

https://github.com/google/bumble/actions/runs/19744613888/job/56576239595?pr=827

Fixing the version to 1.11.0 should be helpful.