### PR TITLE
Fix retrieve ltk key with ediv and rand instead of role

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -4837,10 +4837,18 @@ class Device(utils.CompositeEventEmitter):
                     return keys.ltk.value
 
             # Check both ltk_central and ltk_peripheral by matching EDIV+Rand
-            if keys.ltk_central and keys.ltk_central.ediv == ediv and keys.ltk_central.rand == rand:
+            if (
+                keys.ltk_central
+                and keys.ltk_central.ediv == ediv
+                and keys.ltk_central.rand == rand
+            ):
                 return keys.ltk_central.value
 
-            if keys.ltk_peripheral and keys.ltk_peripheral.ediv == ediv and keys.ltk_peripheral.rand == rand:
+            if (
+                keys.ltk_peripheral
+                and keys.ltk_peripheral.ediv == ediv
+                and keys.ltk_peripheral.rand == rand
+            ):
                 return keys.ltk_peripheral.value
 
         return None

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -4836,11 +4836,13 @@ class Device(utils.CompositeEventEmitter):
                 if keys.ltk:
                     return keys.ltk.value
 
-                if connection.role == hci.Role.CENTRAL and keys.ltk_central:
-                    return keys.ltk_central.value
+            # Check both ltk_central and ltk_peripheral by matching EDIV+Rand
+            if keys.ltk_central and keys.ltk_central.ediv == ediv and keys.ltk_central.rand == rand:
+                return keys.ltk_central.value
 
-                if connection.role == hci.Role.PERIPHERAL and keys.ltk_peripheral:
-                    return keys.ltk_peripheral.value
+            if keys.ltk_peripheral and keys.ltk_peripheral.ediv == ediv and keys.ltk_peripheral.rand == rand:
+                return keys.ltk_peripheral.value
+
         return None
 
     async def get_link_key(self, address: hci.Address) -> bytes | None:

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -4836,20 +4836,20 @@ class Device(utils.CompositeEventEmitter):
                 if keys.ltk:
                     return keys.ltk.value
 
-            # Check both ltk_central and ltk_peripheral by matching EDIV+Rand
-            if (
-                keys.ltk_central
-                and keys.ltk_central.ediv == ediv
-                and keys.ltk_central.rand == rand
-            ):
-                return keys.ltk_central.value
+                # Check both ltk_central and ltk_peripheral by matching EDIV+Rand
+                if (
+                    keys.ltk_central
+                    and keys.ltk_central.ediv == ediv
+                    and keys.ltk_central.rand == rand
+                ):
+                    return keys.ltk_central.value
 
-            if (
-                keys.ltk_peripheral
-                and keys.ltk_peripheral.ediv == ediv
-                and keys.ltk_peripheral.rand == rand
-            ):
-                return keys.ltk_peripheral.value
+                if (
+                    keys.ltk_peripheral
+                    and keys.ltk_peripheral.ediv == ediv
+                    and keys.ltk_peripheral.rand == rand
+                ):
+                    return keys.ltk_peripheral.value
 
         return None
 

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -51,6 +51,7 @@ from bumble.hci import (
     Role,
 )
 from bumble.host import DataPacketQueue, Host
+from bumble.keys import PairingKeys
 
 from .test_utils import TwoDevices, async_barrier
 
@@ -823,6 +824,92 @@ async def test_remote_name_request():
     actual_name = await devices[0].request_remote_name(devices[1].public_address)
     assert actual_name == expected_name
 
+# -----------------------------------------------------------------------------
+@pytest.fixture
+def device_with_connection() -> Device:
+    """Device with a registered LE connection and an SMP manager that has no LTK."""
+    device = Device(host=Host(None, None))
+    peer_address = Address('AA:BB:CC:DD:EE:FF', address_type=Address.RANDOM_DEVICE_ADDRESS)
+    connection = Connection(
+        device=device,
+        handle=0x0001,
+        transport=PhysicalTransport.LE,
+        self_address=Address('11:22:33:44:55:66'),
+        self_resolvable_address=None,
+        peer_address=peer_address,
+        peer_resolvable_address=None,
+        role=Role.CENTRAL,
+        parameters=Connection.Parameters(
+            connection_interval=10.0,
+            peripheral_latency=0,
+            supervision_timeout=720.0,
+        ),
+    )
+    device.connections[0x0001] = connection
+    device.smp_manager = mock.MagicMock()
+    device.smp_manager.get_long_term_key.return_value = None
+    return device
+
+
+# -----------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_long_term_key_no_keystore(device_with_connection):
+    """Returns None when no keystore is configured and SMP has no key."""
+    device_with_connection.keystore = None
+
+    result = await device_with_connection.get_long_term_key(connection_handle=0x0001, rand=b'\x00' * 8, ediv=0)
+
+    assert result is None
+
+# -----------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    'keys, rand, ediv, expected_ltk',
+    [
+        pytest.param(
+            PairingKeys(ltk=PairingKeys.Key(value=b'\x02' * 16)),
+            b'\xaa' * 8,
+            0x1234,
+            b'\x02' * 16,
+            id='legacy_ltk',
+        ),
+        pytest.param(
+            PairingKeys(ltk_central=PairingKeys.Key(value=b'\x03' * 16, ediv=0x5678, rand=b'\xbb' * 8)),
+            b'\xbb' * 8,
+            0x5678,
+            b'\x03' * 16,
+            id='ltk_central_matching_ediv_rand',
+        ),
+        pytest.param(
+            PairingKeys(ltk_peripheral=PairingKeys.Key(value=b'\x04' * 16, ediv=0x9ABC, rand=b'\xcc' * 8)),
+            b'\xcc' * 8,
+            0x9ABC,
+            b'\x04' * 16,
+            id='ltk_peripheral_matching_ediv_rand',
+        ),
+        pytest.param(
+            PairingKeys(ltk_central=PairingKeys.Key(value=b'\x05' * 16, ediv=0x0001, rand=b'\xdd' * 8)),
+            b'\xff' * 8,
+            0x0002,
+            None,
+            id='ltk_central_wrong_ediv_rand',
+        ),
+        pytest.param(
+            None,
+            b'\x00' * 8,
+            0,
+            None,
+            id='keystore_no_entry',
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_long_term_key_from_keystore(device_with_connection, keys, rand, ediv, expected_ltk):
+    keystore = mock.AsyncMock()
+    keystore.get.return_value = keys
+    device_with_connection.keystore = keystore
+
+    result = await device_with_connection.get_long_term_key(connection_handle=0x0001, rand=rand, ediv=ediv)
+    assert result == expected_ltk
 
 # -----------------------------------------------------------------------------
 async def run_test_device():


### PR DESCRIPTION
## Fix: Incorrect LTK Retrieved on Reconnection Causing MIC Failures

### Context 

In my test I simulate a peripheral device that use legacy OOB :
<img width="498" height="49" alt="image" src="https://github.com/user-attachments/assets/c38bd21c-8c95-46ae-8f32-555c8adfa5d2" />

And try to do a connection, disconnection and then a reconnection with a Central.
The first connection works without any issue, but the second connection fails with some MIC failure 100% of my test.

### Problem
When a previously paired device reconnects and the controller requests the Long Term Key (LTK) via `HCI_LE_Long_Term_Key_Request_Event`, Bumble was returning the wrong LTK key, resulting in connection termination with error code `0x3D` (Connection Terminated Due To MIC Failure).

### Root Cause
The bug occurred due to a mismatch between **storage logic** (based on pairing role) and **retrieval logic** (based on connection role):

**Storage (smp.py:1376-1381):**
- Keys are stored based on **pairing initiator role** (`is_initiator`)
- When device is pairing **responder**: `ltk_central = our_ltk`, `ltk_peripheral = peer_ltk`

**Retrieval (device.py - before fix):**
- Keys were retrieved based on **connection role** (`connection.role`)
- When device is connection **peripheral**: fetched `ltk_peripheral` → returned peer's LTK 

**The Issue:**
In normal/expected scenarios where the central initiates pairing:
- Device acting as **peripheral** (connection role) is also the **responder** (pairing role)
- Storage puts our LTK in `ltk_central` field
- Retrieval tries to fetch from `ltk_peripheral` field
- **Result: Peer's LTK returned instead of our own LTK**

### Documentation 

[The Peripheral may store the mapping between EDIV, Rand and LTK in a security database so the correct LTK value is used when the Central requests encryption.](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/security-manager-specification.html#UUID-1dec5bcc-23fb-f492-c8ac-04c062ef49ee)

### Solution
Match LTKs using their cryptographic identifiers (EDIV + Rand) instead of relying on role-based field names:
I am not sure if the change is only valid for the legacy version or not.

```python
# Check both ltk_central and ltk_peripheral by matching EDIV+Rand
if keys.ltk_central and keys.ltk_central.ediv == ediv and keys.ltk_central.rand == rand:
    return keys.ltk_central.value
if keys.ltk_peripheral and keys.ltk_peripheral.ediv == ediv and keys.ltk_peripheral.rand == rand:
    return keys.ltk_peripheral.value

