### PR TITLE
Host: Fix pending_response and semaphore race condition

### DIFF
--- a/bumble/host.py
+++ b/bumble/host.py
@@ -669,35 +669,28 @@ class Host(utils.EventEmitter):
         response_timeout: float | None = None,
     ) -> hci.HCI_Command_Complete_Event | hci.HCI_Command_Status_Event:
         # Wait until we can send (only one pending command at a time)
-        await self.command_semaphore.acquire()
+        async with self.command_semaphore:
+            # Create a future value to hold the eventual response
+            assert self.pending_command is None
+            assert self.pending_response is None
+            self.pending_response = asyncio.get_running_loop().create_future()
+            self.pending_command = command
 
-        # Create a future value to hold the eventual response
-        assert self.pending_command is None
-        assert self.pending_response is None
-        self.pending_response = asyncio.get_running_loop().create_future()
-        self.pending_command = command
-
-        response: (
-            hci.HCI_Command_Complete_Event | hci.HCI_Command_Status_Event | None
-        ) = None
-        try:
-            self.send_hci_packet(command)
-            response = await asyncio.wait_for(
-                self.pending_response, timeout=response_timeout
-            )
-            return response
-        except Exception:
-            logger.exception(color("!!! Exception while sending command:", "red"))
-            raise
-        finally:
-            self.pending_command = None
-            self.pending_response = None
-            if (
-                response is not None
-                and response.num_hci_command_packets
-                and self.command_semaphore.locked()
-            ):
-                self.command_semaphore.release()
+            response: (
+                hci.HCI_Command_Complete_Event | hci.HCI_Command_Status_Event | None
+            ) = None
+            try:
+                self.send_hci_packet(command)
+                response = await asyncio.wait_for(
+                    self.pending_response, timeout=response_timeout
+                )
+                return response
+            except Exception:
+                logger.exception(color("!!! Exception while sending command:", "red"))
+                raise
+            finally:
+                self.pending_command = None
+                self.pending_response = None
 
     @overload
     async def send_command(
@@ -990,8 +983,9 @@ class Host(utils.EventEmitter):
 
     def on_transport_lost(self):
         # Called by the source when the transport has been lost.
-        if self.pending_response:
+        if self.pending_response and not self.pending_response.done():
             self.pending_response.set_exception(TransportLostError('transport lost'))
+            self.pending_response = None
 
         self.emit('flush')
 
@@ -1054,11 +1048,13 @@ class Host(utils.EventEmitter):
                     f'0x{event.command_opcode:X}'
                 )
 
-            self.pending_response.set_result(event)
+            if self.pending_response.done():
+                logger.warning('!!! pending response already set')
+            else:
+                self.pending_response.set_result(event)
+                self.pending_response = None
         else:
             logger.warning('!!! no pending response future to set')
-            if event.num_hci_command_packets and self.command_semaphore.locked():
-                self.command_semaphore.release()
 
     ############################################################
     # HCI handlers
@@ -1072,10 +1068,10 @@ class Host(utils.EventEmitter):
             # an actual command
             logger.debug('no-command event for flow control')
 
-            # Release the command semaphore if needed
-            if event.num_hci_command_packets and self.command_semaphore.locked():
-                logger.debug('command complete event releasing semaphore')
-                self.command_semaphore.release()
+            if self.pending_response and not self.pending_response.done():
+                logger.debug('Cancel pending response')
+                self.pending_response.cancel()
+                self.pending_response = None
 
             return
 


### PR DESCRIPTION
Actually I am not sure whether this can work. Recently we see some issues like:

```py
03-11 13:44:42.288 DEBUG    [bumble.Host:00:02] Advertise
03-11 13:44:42.289 DEBUG    ### HOST -> CONTROLLER: HCI_LE_SET_EXTENDED_ADVERTISING_PARAMETERS_COMMAND:
  advertising_handle:               0
  advertising_event_properties:     CONNECTABLE_ADVERTISING|SCANNABLE_ADVERTISING|USE_LEGACY_ADVERTISING_PDUS
  primary_advertising_interval_min: 320
  primary_advertising_interval_max: 320
  primary_advertising_channel_map:  CHANNEL_37|CHANNEL_38|CHANNEL_39
  own_address_type:                 RANDOM
  peer_address_type:                PUBLIC_DEVICE
  peer_address:                     00:00:00:00:00:00/P
  advertising_filter_policy:        0
  advertising_tx_power:             127
  primary_advertising_phy:          LE_1M
  secondary_advertising_max_skip:   0
  secondary_advertising_phy:        LE_1M
  advertising_sid:                  0
  scan_request_notification_enable: 0
03-11 13:44:42.289 DEBUG    ### CONTROLLER -> HOST: HCI_NUMBER_OF_COMPLETED_PACKETS_EVENT:
  connection_handles[0]:    0
  num_completed_packets[0]: 1
03-11 13:44:42.290 DEBUG    ### CONTROLLER -> HOST: ACL: handle=0x0000, pb=2, bc=0, data_total_length=12, data=080001000606040040004000
03-11 13:44:42.290 DEBUG    <<< ACL PDU: 080001000606040040004000
03-11 13:44:42.290 DEBUG    <<< Received L2CAP Signaling Control Frame on connection [0x0000] (CID=1) DA:4C:10:DE:00:00/P:
L2CAP_DISCONNECTION_REQUEST [ID=6]:
  destination_cid: 64
  source_cid:      64
03-11 13:44:42.290 DEBUG    >>> Sending L2CAP Signaling Control Frame on connection [0x0000] (CID=1) DA:4C:10:DE:00:00/P:
L2CAP_DISCONNECTION_RESPONSE [ID=6]:
  destination_cid: 64
  source_cid:      64
03-11 13:44:42.290 DEBUG    >>> ACL packet enqueue: (handle=0x0000) 080001000706040040004000
03-11 13:44:42.290 DEBUG    ### HOST -> CONTROLLER: ACL: handle=0x0000, pb=0, bc=0, data_total_length=12, data=080001000706040040004000
03-11 13:44:42.290 DEBUG    Channel(64->64, PSM=1, MTU=2048/1024, state=OPEN) state change -> CLOSED
03-11 13:44:42.335 DEBUG    ### CONTROLLER -> HOST: HCI_COMMAND_COMPLETE_EVENT:
  num_hci_command_packets: 1
  command_opcode:          HCI_LE_SET_EXTENDED_ADVERTISING_PARAMETERS_COMMAND
  return_parameters:       
    status:            SUCCESS
    selected_tx_power: 127
03-11 13:44:42.336 DEBUG    ### HOST -> CONTROLLER: HCI_LE_SET_ADVERTISING_SET_RANDOM_ADDRESS_COMMAND:
  advertising_handle: 0
  random_address:     51:F7:A8:75:AC:5E
03-11 13:44:42.338 DEBUG    ### CONTROLLER -> HOST: HCI_NUMBER_OF_COMPLETED_PACKETS_EVENT:
  connection_handles[0]:    0
  num_completed_packets[0]: 1
03-11 13:44:42.339 DEBUG    ### CONTROLLER -> HOST: ACL: handle=0x0000, pb=2, bc=0, data_total_length=12, data=080001000207040001004200
03-11 13:44:42.339 DEBUG    <<< ACL PDU: 080001000207040001004200
03-11 13:44:42.339 DEBUG    <<< Received L2CAP Signaling Control Frame on connection [0x0000] (CID=1) DA:4C:10:DE:00:00/P:
L2CAP_CONNECTION_REQUEST [ID=7]:
  psm:        1
  source_cid: 66
03-11 13:44:42.339 DEBUG    creating server channel with cid=64 for psm 1
03-11 13:44:42.340 DEBUG    Channel(64->66, PSM=1, MTU=2048/48, state=CLOSED) state change -> WAIT_CONNECT
03-11 13:44:42.340 DEBUG    >>> Sending L2CAP Signaling Control Frame on connection [0x0000] (CID=1) DA:4C:10:DE:00:00/P:
L2CAP_CONNECTION_RESPONSE [ID=7]:
  destination_cid: 64
  source_cid:      66
  result:          CONNECTION_SUCCESSFUL
  status:          0
03-11 13:44:42.340 DEBUG    >>> ACL packet enqueue: (handle=0x0000) 0c000100030708004000420000000000
03-11 13:44:42.342 DEBUG    ### HOST -> CONTROLLER: ACL: handle=0x0000, pb=0, bc=0, data_total_length=16, data=0c000100030708004000420000000000
03-11 13:44:42.342 DEBUG    Channel(64->66, PSM=1, MTU=2048/48, state=WAIT_CONNECT) state change -> WAIT_CONFIG
03-11 13:44:42.343 DEBUG    >>> Sending L2CAP Signaling Control Frame on connection [0x0000] (CID=1) DA:4C:10:DE:00:00/P:
L2CAP_CONFIGURE_REQUEST [ID=2]:
  destination_cid: 66
  flags:           0
  options:         01020008
03-11 13:44:42.343 DEBUG    >>> ACL packet enqueue: (handle=0x0000) 0c000100040208004200000001020008
03-11 13:44:42.343 DEBUG    ### HOST -> CONTROLLER: ACL: handle=0x0000, pb=0, bc=0, data_total_length=16, data=0c000100040208004200000001020008
03-11 13:44:42.343 DEBUG    Channel(64->66, PSM=1, MTU=2048/48, state=WAIT_CONFIG) state change -> WAIT_CONFIG_REQ_RSP
03-11 13:44:42.351 DEBUG    ### CONTROLLER -> HOST: HCI_COMMAND_COMPLETE_EVENT:
  num_hci_command_packets: 1
  command_opcode:          HCI_LE_SET_ADVERTISING_SET_RANDOM_ADDRESS_COMMAND
  return_parameters:       
    status: SUCCESS
03-11 13:44:42.352 DEBUG    ### HOST -> CONTROLLER: HCI_LE_SET_EXTENDED_ADVERTISING_ENABLE_COMMAND:
  enable:                             1
  advertising_handles[0]:             0
  durations[0]:                       0
  max_extended_advertising_events[0]: 0
03-11 13:44:42.356 DEBUG    ### CONTROLLER -> HOST: HCI_NUMBER_OF_COMPLETED_PACKETS_EVENT:
  connection_handles[0]:    0
  num_completed_packets[0]: 1
03-11 13:44:42.405 DEBUG    ### CONTROLLER -> HOST: HCI_NUMBER_OF_COMPLETED_PACKETS_EVENT:
  connection_handles[0]:    0
  num_completed_packets[0]: 1
03-11 13:44:42.405 DEBUG    ### CONTROLLER -> HOST: HCI_COMMAND_COMPLETE_EVENT:
  num_hci_command_packets: 1
  command_opcode:          HCI_LE_SET_EXTENDED_ADVERTISING_ENABLE_COMMAND
  return_parameters:       
    status: SUCCESS
03-11 13:44:42.405 ERROR    !!! Exception in on_packet
Traceback (most recent call last):
  File "bumble/transport/common.py", line 160, in feed_data
  File "bumble/host.py", line 985, in on_packet
  File "bumble/host.py", line 1008, in on_hci_packet
  File "bumble/host.py", line 1024, in on_hci_event_packet
  File "bumble/host.py", line 1081, in on_hci_command_complete_event
  File "bumble/host.py", line 1056, in on_command_processed
asyncio.exceptions.InvalidStateError: invalid state

```

Or

```py
02-09 17:41:02.106 DEBUG    ### HOST -> CONTROLLER: HCI_LE_SET_EXTENDED_ADVERTISING_ENABLE_COMMAND:
  enable:                             1
  advertising_handles[0]:             0
  durations[0]:                       0
  max_extended_advertising_events[0]: 0
02-09 17:41:02.106 DEBUG    [bumble.Host:17:03] FactoryReset
02-09 17:41:02.110 DEBUG    ### CONTROLLER -> HOST: HCI_COMMAND_COMPLETE_EVENT:
  num_hci_command_packets: 1
  command_opcode:          HCI_LE_SET_EXTENDED_ADVERTISING_ENABLE_COMMAND
  return_parameters:       
    status: SUCCESS
02-09 17:41:02.110 ERROR    !!! Exception in on_packet
Traceback (most recent call last):
  File "bumble/transport/common.py", line 160, in feed_data
  File "bumble/host.py", line 985, in on_packet
  File "bumble/host.py", line 1008, in on_hci_packet
  File "bumble/host.py", line 1024, in on_hci_event_packet
  File "bumble/host.py", line 1081, in on_hci_command_complete_event
  File "bumble/host.py", line 1056, in on_command_processed
asyncio.exceptions.InvalidStateError: invalid state
02-09 17:41:02.111 DEBUG    [bumble.Host:17:03] Stop advertising
02-09 17:41:02.111 DEBUG    RPC cancelled for servicer method [/pandora.Host/Advertise]
```

Thus HCI_LE_SET_EXTENDED_ADVERTISING_ENABLE_COMMAND usually failed and blocked some other commands. One thing noticable is this only happened to Pandora, and only on HCI_LE_SET_EXTENDED_ADVERTISING_ENABLE_COMMAND...
