### PR TITLE
release command semaphore after timeout

### DIFF
--- a/bumble/host.py
+++ b/bumble/host.py
@@ -692,10 +692,8 @@ class Host(utils.EventEmitter):
         finally:
             self.pending_command = None
             self.pending_response = None
-            if (
-                response is not None
-                and response.num_hci_command_packets
-                and self.command_semaphore.locked()
+            if response is None or (
+                response.num_hci_command_packets and self.command_semaphore.locked()
             ):
                 self.command_semaphore.release()
 

--- a/tests/host_test.py
+++ b/tests/host_test.py
@@ -171,14 +171,15 @@ class Source:
 
 
 class Sink:
-    response: HCI_Event
+    response: HCI_Event | None
 
-    def __init__(self, source: Source, response: HCI_Event) -> None:
+    def __init__(self, source: Source, response: HCI_Event | None) -> None:
         self.source = source
         self.response = response
 
     def on_packet(self, packet: bytes) -> None:
-        self.source.sink.on_packet(bytes(self.response))
+        if self.response is not None:
+            self.source.sink.on_packet(bytes(self.response))
 
 
 @pytest.mark.asyncio
@@ -226,6 +227,23 @@ async def test_send_sync_command() -> None:
     )
     response3 = await host.send_sync_command_raw(command)  # type: ignore
     assert isinstance(response3.return_parameters, HCI_GenericReturnParameters)
+
+
+@pytest.mark.asyncio
+async def test_send_sync_command_timeout() -> None:
+    source = Source()
+    sink = Sink(source, None)
+
+    host = Host(source, sink)
+    host.ready = True
+
+    with pytest.raises(asyncio.TimeoutError):
+        await host.send_sync_command(HCI_Reset_Command(), response_timeout=0.01)
+
+    # The sending semaphore should have been released, so this should not block
+    # indefinitely
+    with pytest.raises(asyncio.TimeoutError):
+        await host.send_sync_command(hci.HCI_Reset_Command(), response_timeout=0.01)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
As described in issue #910, if the controller doesn't send a response in time, a timeout exception is caught, but the command semaphore isn't released, which prevents any further use of the controller.
With this change, the command semaphore will be released (and the caller will be responsible for catching the timeout). This is of course an undefined state (if the controller didn't send a response, there's no way to predict if the controller will work at all after the timeout), but it may be useful for "flaky" controllers that may still be usable after a timeout.
