### PR TITLE
fix crash in `bumble.att.Attribute.__repr__`

### DIFF
--- a/bumble/att.py
+++ b/bumble/att.py
@@ -1083,7 +1083,7 @@ class Attribute(utils.EventEmitter, Generic[_T]):
         else:
             value_str = str(self.value)
         if value_str:
-            value_string = f', value={self.value.hex()}'
+            value_string = f', value={value_str}'
         else:
             value_string = ''
         return (


### PR DESCRIPTION
If an attribute does not contains a bytes value, it would crash with something like:

    AttributeError: 'NoneType' object has no attribute 'hex'

Clearly, the intention here was to use `value_str` to avoid this possibility.