### PR TITLE
Fix regex syntax warning in sdp_test.py.

### DIFF
--- a/tests/sdp_test.py
+++ b/tests/sdp_test.py
@@ -215,7 +215,7 @@ def test_pdu_parameter_length(caplog) -> None:
         transaction_id=0, error_code=sdp.ErrorCode.INVALID_SDP_VERSION
     )
     assert sdp.SDP_PDU.from_bytes(bytes(pdu)) == pdu
-    assert not re.search("Expect \d+ bytes, got \d+", caplog.text)
+    assert not re.search(r"Expect \d+ bytes, got \d+", caplog.text)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Change regex match string to raw string to avoid syntax warning:

    tests/sdp_test.py:218: SyntaxWarning: invalid escape sequence '\d'
    assert not re.search("Expect \d+ bytes, got \d+", caplog.text)

In the future, this will become an error, so we should fix it now.