### PR TITLE
fix: host race condition on hci acl data packets

### DIFF
--- a/bumble/host.py
+++ b/bumble/host.py
@@ -17,6 +17,7 @@
 # -----------------------------------------------------------------------------
 from __future__ import annotations
 
+import time
 import asyncio
 import collections
 import dataclasses
@@ -256,6 +257,8 @@ class Host(utils.EventEmitter):
     long_term_key_provider: Callable[[int, bytes, int], Awaitable[bytes | None]] | None
     link_key_provider: Callable[[hci.Address], Awaitable[bytes | None]] | None
 
+    _ACL_STALE_TIMEOUT_S: float = 0.100  # 100 ms
+
     def __init__(
         self,
         controller_source: TransportSource | None = None,
@@ -293,6 +296,9 @@ class Host(utils.EventEmitter):
         self.link_key_provider = None
         self.pairing_io_capability_provider = None  # Classic only
         self.snooper: Snooper | None = None
+        self._pending_acl: dict[int, list[tuple[float, hci.HCI_AclDataPacket]]] = {}
+        self._cleanup_task: asyncio.Task[None] | None = None
+        self.on("le_connection", self._drain_buffered_acl)
 
         # Connect to the source and sink if specified
         if controller_source:
@@ -1033,6 +1039,16 @@ class Host(utils.EventEmitter):
         if connection := self.connections.get(packet.connection_handle):
             connection.on_hci_acl_data_packet(packet)
             return
+        logger.warning(
+            f"ACL data arrived before Connection Complete for handle {packet.connection_handle} — buffering"
+        )
+        self._pending_acl.setdefault(packet.connection_handle, []).append(
+            (time.monotonic(), packet)
+        )
+        if self._cleanup_task is None or self._cleanup_task.done():
+            self._cleanup_task = asyncio.get_event_loop().create_task(
+                self._clean_pending_acl_to_old()
+            )
 
         # WORKAROUND: Some controllers (e.g. Intel BE200) send ISO data wrapped in ACL packets
         # using the CIS handle.
@@ -1119,6 +1135,37 @@ class Host(utils.EventEmitter):
 
     def on_l2cap_pdu(self, connection: Connection, cid: int, pdu: bytes) -> None:
         self.emit('l2cap_pdu', connection.handle, cid, pdu)
+
+    async def _clean_pending_acl_to_old(self) -> None:
+        """Periodically discard buffered ACL packets that have exceeded the timeout."""
+        while self._pending_acl:
+            await asyncio.sleep(self._ACL_STALE_TIMEOUT_S)
+            now = time.monotonic()
+            for handle in list(self._pending_acl):
+                acl_to_keep, acl_timed_out = [], []
+                for ts, packet in self._pending_acl[handle]:
+                    (acl_to_keep if (now - ts) <= self._ACL_STALE_TIMEOUT_S else acl_timed_out).append((ts, packet))
+                for ts, _ in acl_timed_out:
+                    logger.critical(
+                        f"Dropping stale buffered ACL packet for handle {handle}"
+                        f" (age {(now - ts) * self._ACL_STALE_TIMEOUT_S * 10000} ms > "
+                        f"{self._ACL_STALE_TIMEOUT_S * self._ACL_STALE_TIMEOUT_S * 10000} ms timeout)"
+                    )
+                if acl_to_keep:
+                    self._pending_acl[handle] = acl_to_keep
+                else:
+                    del self._pending_acl[handle]
+
+    def _drain_buffered_acl(self, handle: int, *_args: Any, **_kwargs: Any) -> None:
+        """Once le connection happen emit the buffered packets"""
+        queued = self._pending_acl.pop(handle, [])
+        if not queued:
+            return
+        for ts, packet in queued:
+            logger.info(
+                f"Replaying buffered ACL packet for handle handle (age {(time.monotonic() - ts) * 1000} ms)"
+            )
+            self.on_hci_acl_data_packet(packet)
 
     def on_command_processed(
         self, event: hci.HCI_Command_Complete_Event | hci.HCI_Command_Status_Event

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -297,7 +297,7 @@ class Host(utils.EventEmitter):
         self.pairing_io_capability_provider = None  # Classic only
         self.snooper: Snooper | None = None
         self._pending_acl: dict[int, list[tuple[float, hci.HCI_AclDataPacket]]] = {}
-        self._cleanup_task: asyncio.Task[None] | None = None
+        self._drain_acl_buffer_task: asyncio.Task[None] | None = None
         self.on("le_connection", self._drain_buffered_acl)
 
         # Connect to the source and sink if specified
@@ -1046,10 +1046,6 @@ class Host(utils.EventEmitter):
         self._pending_acl.setdefault(packet.connection_handle, []).append(
             (time.monotonic(), packet)
         )
-        if self._cleanup_task is None or self._cleanup_task.done():
-            self._cleanup_task = asyncio.get_event_loop().create_task(
-                self._clean_pending_acl_to_old()
-            )
 
         # WORKAROUND: Some controllers (e.g. Intel BE200) send ISO data wrapped in ACL packets
         # using the CIS handle.
@@ -1137,48 +1133,24 @@ class Host(utils.EventEmitter):
     def on_l2cap_pdu(self, connection: Connection, cid: int, pdu: bytes) -> None:
         self.emit('l2cap_pdu', connection.handle, cid, pdu)
 
-    async def _clean_pending_acl_to_old(self) -> None:
-        """Periodically discard buffered ACL packets that have exceeded the timeout."""
-        while self._pending_acl:
-            await asyncio.sleep(self._ACL_STALE_TIMEOUT_S)
-            now = time.monotonic()
-            for handle in list(self._pending_acl):
-                acl_to_keep: list[tuple[float, hci.HCI_AclDataPacket]] = []
-                acl_timed_out: list[tuple[float, hci.HCI_AclDataPacket]] = []
-                for ts, packet in self._pending_acl[handle]:
-                    (
-                        acl_to_keep
-                        if (now - ts) <= self._ACL_STALE_TIMEOUT_S
-                        else acl_timed_out
-                    ).append((ts, packet))
-                for ts, _ in acl_timed_out:
-                    logger.info(
-                        f"Dropping stale buffered ACL packet for handle {handle}"
-                        f" (age {(now - ts) * self._ACL_STALE_TIMEOUT_S * 1000} ms > "
-                        f"{self._ACL_STALE_TIMEOUT_S * self._ACL_STALE_TIMEOUT_S * 1000} ms timeout)"
-                    )
-                if acl_to_keep:
-                    self._pending_acl[handle] = acl_to_keep
-                else:
-                    del self._pending_acl[handle]
-
     def _drain_buffered_acl_sync(self, handle: int, *args: Any, **kwargs: Any) -> None:
         """Create an async task to replay buffered ACL packet"""
-        self._cleanup_task = asyncio.get_event_loop().create_task(
+        self._drain_acl_buffer_task = asyncio.get_event_loop().create_task(
             self._drain_buffered_acl(handle)
         )
 
     async def _drain_buffered_acl(self, handle: int) -> None:
         """Replay all buffered ACL packet"""
-        await asyncio.sleep(0.1)
         queued = self._pending_acl.pop(handle, [])
         if not queued:
             return
+        now = time.monotonic()
+        logger.info(f"Replaying buffered ACL packets for handle: {handle}")
         for ts, packet in queued:
-            logger.info(
-                f"Replaying buffered ACL packet for handle handle (age {(time.monotonic() - ts) * 1000} ms)"
-            )
-            self.on_hci_acl_data_packet(packet)
+            # Sleep to allow other tasks to run
+            await asyncio.sleep(0)
+            if (now - ts) <= self._ACL_STALE_TIMEOUT_S:
+                self.on_hci_acl_data_packet(packet)
 
     def on_command_processed(
         self, event: hci.HCI_Command_Complete_Event | hci.HCI_Command_Status_Event

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -1039,6 +1039,7 @@ class Host(utils.EventEmitter):
         if connection := self.connections.get(packet.connection_handle):
             connection.on_hci_acl_data_packet(packet)
             return
+
         logger.warning(
             f"ACL data arrived before Connection Complete for handle {packet.connection_handle} — buffering"
         )
@@ -1142,11 +1143,16 @@ class Host(utils.EventEmitter):
             await asyncio.sleep(self._ACL_STALE_TIMEOUT_S)
             now = time.monotonic()
             for handle in list(self._pending_acl):
-                acl_to_keep, acl_timed_out = [], []
+                acl_to_keep: list[tuple[float, hci.HCI_AclDataPacket]] = []
+                acl_timed_out: list[tuple[float, hci.HCI_AclDataPacket]] = []
                 for ts, packet in self._pending_acl[handle]:
-                    (acl_to_keep if (now - ts) <= self._ACL_STALE_TIMEOUT_S else acl_timed_out).append((ts, packet))
+                    (
+                        acl_to_keep
+                        if (now - ts) <= self._ACL_STALE_TIMEOUT_S
+                        else acl_timed_out
+                    ).append((ts, packet))
                 for ts, _ in acl_timed_out:
-                    logger.critical(
+                    logger.info(
                         f"Dropping stale buffered ACL packet for handle {handle}"
                         f" (age {(now - ts) * self._ACL_STALE_TIMEOUT_S * 10000} ms > "
                         f"{self._ACL_STALE_TIMEOUT_S * self._ACL_STALE_TIMEOUT_S * 10000} ms timeout)"
@@ -1156,8 +1162,15 @@ class Host(utils.EventEmitter):
                 else:
                     del self._pending_acl[handle]
 
-    def _drain_buffered_acl(self, handle: int, *_args: Any, **_kwargs: Any) -> None:
-        """Once le connection happen emit the buffered packets"""
+    def _drain_buffered_acl_sync(self, handle: int, *args: Any, **kwargs: Any) -> None:
+        """Create an async task to replay buffered ACL packet"""
+        self._cleanup_task = asyncio.get_event_loop().create_task(
+            self._drain_buffered_acl(handle)
+        )
+
+    async def _drain_buffered_acl(self, handle: int) -> None:
+        """Replay all buffered ACL packet"""
+        await asyncio.sleep(0.1)
         queued = self._pending_acl.pop(handle, [])
         if not queued:
             return

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -257,7 +257,7 @@ class Host(utils.EventEmitter):
     long_term_key_provider: Callable[[int, bytes, int], Awaitable[bytes | None]] | None
     link_key_provider: Callable[[hci.Address], Awaitable[bytes | None]] | None
 
-    _ACL_STALE_TIMEOUT_S: float = 0.100  # 100 ms
+    _ACL_STALE_TIMEOUT_S: float = 0.500  # 500 ms
 
     def __init__(
         self,
@@ -1154,8 +1154,8 @@ class Host(utils.EventEmitter):
                 for ts, _ in acl_timed_out:
                     logger.info(
                         f"Dropping stale buffered ACL packet for handle {handle}"
-                        f" (age {(now - ts) * self._ACL_STALE_TIMEOUT_S * 10000} ms > "
-                        f"{self._ACL_STALE_TIMEOUT_S * self._ACL_STALE_TIMEOUT_S * 10000} ms timeout)"
+                        f" (age {(now - ts) * self._ACL_STALE_TIMEOUT_S * 1000} ms > "
+                        f"{self._ACL_STALE_TIMEOUT_S * self._ACL_STALE_TIMEOUT_S * 1000} ms timeout)"
                     )
                 if acl_to_keep:
                     self._pending_acl[handle] = acl_to_keep


### PR DESCRIPTION
After some analysis, we found that we had some race condition on acl data packets which arrived before the connection complete

This PR add a fix for the race condition where ACL data can arrive before the corresponding Connection Complete event.
Use a buffer to store packets by handle and replaying them once the connection is established.
And buffered packets are removed after a delay of 100ms


Analysis:
When a BLE central connects to the nRF52840 dongle and immediately sends an SMP Pairing Request, the ACL data packet is delivered to Bumble before the LE Connection Complete event due to USB endpoint ordering, causing Bumble to drop the pairing request for an unknown connection handle and leaving the pairing stuck until the connection times out.