### PR TITLE
remove trailing commas in pytest parametrize argname

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,9 @@ dependencies = [
 [project.optional-dependencies]
 build = ["build >= 0.7"]
 test = [
-    "pytest >= 8.2",
-    "pytest-asyncio >= 0.23.5",
-    "pytest-html >= 3.2.0",
+    "pytest >= 9.0",
+    "pytest-asyncio >= 1.4",
+    "pytest-html >= 4.2",
     "coverage >= 6.4",
 ]
 development = [

--- a/tests/avrcp_test.py
+++ b/tests/avrcp_test.py
@@ -46,7 +46,7 @@ class TwoDevices(test_utils.TwoDevices):
 
 
 @pytest.mark.parametrize(
-    "command,",
+    "command",
     [
         avrcp.GetPlayStatusCommand(),
         avrcp.GetCapabilitiesCommand(
@@ -132,7 +132,7 @@ def test_command(command: avrcp.Command):
 
 
 @pytest.mark.parametrize(
-    "event,",
+    "event",
     [
         avrcp.UidsChangedEvent(uid_counter=7),
         avrcp.TrackChangedEvent(uid=12356),
@@ -159,7 +159,7 @@ def test_event(event: avrcp.Event):
 
 
 @pytest.mark.parametrize(
-    "response,",
+    "response",
     [
         avrcp.GetPlayStatusResponse(
             song_length=1010, song_position=13, play_status=avrcp.PlayStatus.PAUSED

--- a/tests/csip_test.py
+++ b/tests/csip_test.py
@@ -72,7 +72,7 @@ def test_sef():
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    'sirk_type,', [(csip.SirkType.ENCRYPTED), (csip.SirkType.PLAINTEXT)]
+    'sirk_type', [(csip.SirkType.ENCRYPTED), (csip.SirkType.PLAINTEXT)]
 )
 async def test_csis(sirk_type):
     SIRK = bytes.fromhex('2f62c8ae41867d1bb619e788a2605faa')

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -278,7 +278,7 @@ async def test_legacy_advertising():
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    'auto_restart,',
+    'auto_restart',
     (True, False),
 )
 @pytest.mark.asyncio
@@ -357,7 +357,7 @@ async def test_advertising_and_scanning():
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    'own_address_type,',
+    'own_address_type',
     (OwnAddressType.PUBLIC, OwnAddressType.RANDOM),
 )
 @pytest.mark.asyncio
@@ -395,7 +395,7 @@ async def test_extended_advertising_connection(own_address_type):
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    'own_address_type,',
+    'own_address_type',
     (OwnAddressType.PUBLIC, OwnAddressType.RANDOM),
 )
 @pytest.mark.asyncio

--- a/tests/hci_test.py
+++ b/tests/hci_test.py
@@ -297,7 +297,7 @@ def test_custom_le_meta_event():
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "clazz,",
+    "clazz",
     [
         clazz[1]
         for clazz in inspect.getmembers(hci)
@@ -313,7 +313,7 @@ def test_hci_command_subclasses_op_code(clazz: type[hci.HCI_Command]):
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "clazz,",
+    "clazz",
     [
         clazz[1]
         for clazz in inspect.getmembers(hci)
@@ -330,7 +330,7 @@ def test_hci_event_subclasses_event_code(clazz: type[hci.HCI_Event]):
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "clazz,",
+    "clazz",
     [
         clazz[1]
         for clazz in inspect.getmembers(hci)

--- a/tests/hfp_test.py
+++ b/tests/hfp_test.py
@@ -333,7 +333,7 @@ async def test_query_calls_with_calls(
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "operation,",
+    "operation",
     (
         hfp.CallHoldOperation.RELEASE_ALL_HELD_CALLS,
         hfp.CallHoldOperation.RELEASE_ALL_ACTIVE_CALLS,
@@ -358,7 +358,7 @@ async def test_hold_call_without_call_index(
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "operation,",
+    "operation",
     (
         hfp.CallHoldOperation.RELEASE_SPECIFIC_CALL,
         hfp.CallHoldOperation.HOLD_ALL_CALLS_EXCEPT,

--- a/tests/l2cap_test.py
+++ b/tests/l2cap_test.py
@@ -49,19 +49,19 @@ def test_helpers():
     psm = l2cap.L2CAP_Connection_Request.serialize_psm(0x242311)
     assert psm == bytes([0x11, 0x23, 0x24])
 
-    (offset, psm) = l2cap.L2CAP_Connection_Request.parse_psm(
+    offset, psm = l2cap.L2CAP_Connection_Request.parse_psm(
         bytes([0x00, 0x01, 0x00, 0x44]), 1
     )
     assert offset == 3
     assert psm == 0x01
 
-    (offset, psm) = l2cap.L2CAP_Connection_Request.parse_psm(
+    offset, psm = l2cap.L2CAP_Connection_Request.parse_psm(
         bytes([0x00, 0x23, 0x10, 0x44]), 1
     )
     assert offset == 3
     assert psm == 0x1023
 
-    (offset, psm) = l2cap.L2CAP_Connection_Request.parse_psm(
+    offset, psm = l2cap.L2CAP_Connection_Request.parse_psm(
         bytes([0x00, 0x11, 0x23, 0x24, 0x44]), 1
     )
     assert offset == 4
@@ -197,7 +197,7 @@ async def test_basic_connection():
 
 
 # -----------------------------------------------------------------------------
-@pytest.mark.parametrize("info_type,", list(l2cap.L2CAP_Information_Request.InfoType))
+@pytest.mark.parametrize("info_type", list(l2cap.L2CAP_Information_Request.InfoType))
 async def test_l2cap_information_request(monkeypatch, info_type):
     # TODO: Replace handlers with API when implemented
     devices = await TwoDevices.create_with_connection()
@@ -321,7 +321,7 @@ async def test_mtu():
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mtu,", (50, 255, 256, 1000))
+@pytest.mark.parametrize("mtu", (50, 255, 256, 1000))
 async def test_enhanced_retransmission_mode(mtu: int):
     devices = TwoDevices()
     await devices.setup_connection()

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -68,7 +68,7 @@ async def test_self_disconnection():
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    'responder_role,',
+    'responder_role',
     (Role.CENTRAL, Role.PERIPHERAL),
 )
 async def test_self_classic_connection(responder_role):

--- a/tests/transport_test.py
+++ b/tests/transport_test.py
@@ -102,7 +102,7 @@ def test_parser_extensions():
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "address,",
+    "address",
     ("127.0.0.1", "::1"),
 )
 async def test_tcp_connection(address):
@@ -205,7 +205,7 @@ async def test_unix_connection_abstract():
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "address,",
+    "address",
     ("127.0.0.1", "[::1]"),
 )
 async def test_android_netsim_connection(address):
@@ -228,7 +228,7 @@ async def test_android_netsim_connection(address):
 
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "spec,",
+    "spec",
     (
         "android-netsim:[::1]:{port},mode=host[a=b,c=d]",
         "android-netsim:localhost:{port},mode=host[a=b,c=d]",


### PR DESCRIPTION
Recent versions of pytest stopped allowing non-sequence parameter lists when parameter names are a sequence. This PR just removes the trailing commas in parameter names so that single-name entries are not treated as a list.