### PR TITLE
Bugfix: Ignore libusb callback scheduling after the asyncio loop is closed

### DIFF
--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -38,6 +38,20 @@ logger = logging.getLogger(__name__)
 
 
 # -----------------------------------------------------------------------------
+def _safe_call_soon(loop: asyncio.AbstractEventLoop, callback, *args) -> None:
+    """Schedule `callback` on `loop` from the libusb event thread, tolerating the
+    case where the loop has already been closed during process/transport
+    teardown. Without this guard, a libusb transfer callback that fires after the
+    asyncio loop is closed raises 'Event loop is closed' on the C callback
+    thread, which can escalate to a libusb mutex assertion and crash the process
+    (SIGABRT). This makes an unclean shutdown a no-op instead of a core dump."""
+    try:
+        loop.call_soon_threadsafe(callback, *args)
+    except RuntimeError:
+        pass  # loop already closed; nothing left to schedule
+
+
+# -----------------------------------------------------------------------------
 # Constants
 # -----------------------------------------------------------------------------
 # pylint: disable=invalid-name
@@ -266,7 +280,7 @@ class UsbPacketSink:
         self.packets.put_nowait(packet)
 
     def transfer_callback(self, transfer):
-        self.loop.call_soon_threadsafe(self.out_transfer_ready.release)
+        _safe_call_soon(self.loop, self.out_transfer_ready.release)
         status = transfer.getStatus()
 
         logger.debug(f"OUT CALLBACK: {status}")
@@ -535,8 +549,8 @@ class UsbPacketSource(asyncio.Protocol, BaseSource):
         self.dequeue_task = self.loop.create_task(self.dequeue())
 
     def queue_packet(self, packet_type: int, packet_data: bytes) -> None:
-        self.loop.call_soon_threadsafe(
-            self.queue.put_nowait, bytes([packet_type]) + packet_data
+        _safe_call_soon(
+            self.loop, self.queue.put_nowait, bytes([packet_type]) + packet_data
         )
 
     def transfer_callback(self, transfer):
@@ -582,16 +596,16 @@ class UsbPacketSource(asyncio.Protocol, BaseSource):
                         transfer.submit()
                     except usb1.USBError as error:
                         logger.warning(f"Failed to re-submit transfer: {error}")
-                        self.loop.call_soon_threadsafe(self.on_transport_lost)
+                        _safe_call_soon(self.loop, self.on_transport_lost)
         elif status == usb1.TRANSFER_CANCELLED:
             logger.debug(f"IN[{packet_type}] transfer canceled")
-            self.loop.call_soon_threadsafe(self.done[transfer].set)
+            _safe_call_soon(self.loop, self.done[transfer].set)
         else:
             logger.warning(
                 color(f'!!! IN[{packet_type}] transfer not completed', 'red')
             )
-            self.loop.call_soon_threadsafe(self.done[transfer].set)
-            self.loop.call_soon_threadsafe(self.on_transport_lost)
+            _safe_call_soon(self.loop, self.done[transfer].set)
+            _safe_call_soon(self.loop, self.on_transport_lost)
 
     async def dequeue(self):
         while not self.closed:
@@ -704,7 +718,7 @@ class UsbTransport(Transport):
                 logger.warning(f'!!! Exception while handling events: {error}')
 
         logger.debug('ending USB event loop')
-        self.loop.call_soon_threadsafe(self.event_loop_done.set_result, None)
+        _safe_call_soon(self.loop, self.event_loop_done.set_result, None)
 
     async def close(self):
         self.source.close()

--- a/tests/usb_test.py
+++ b/tests/usb_test.py
@@ -21,6 +21,31 @@ from bumble import hci
 from bumble.transport import usb
 
 
+def test_safe_call_soon_ignores_closed_loop():
+    closed_loop = asyncio.new_event_loop()
+    closed_loop.close()
+    callback = mock.Mock()
+
+    usb._safe_call_soon(closed_loop, callback)
+
+    callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_safe_call_soon_schedules_callback_on_open_loop():
+    called = asyncio.Event()
+    args = []
+
+    def callback(value):
+        args.append(value)
+        called.set()
+
+    usb._safe_call_soon(asyncio.get_running_loop(), callback, 'scheduled')
+
+    await asyncio.wait_for(called.wait(), timeout=1.0)
+    assert args == ['scheduled']
+
+
 @pytest.mark.asyncio
 async def test_usb_packet_sink_iso_routing():
     # Mock usb1 device and endpoints


### PR DESCRIPTION
# Summary

During an unclean USB transport shutdown, the asyncio loop can be closed while a USB transfer is still in flight. When libusb later invokes the transfer completion callback on its C callback thread, Bumble calls `loop.call_soon_threadsafe(...)` on the closed loop. That raises `RuntimeError('Event loop is closed')` on the C callback thread and can escalate
inside libusb to a mutex assertion and process abort (`SIGABRT`).

To reproduce: Start a USB HCI transport, leave an IN or OUT transfer in flight, and close the asyncio loop before libusb delivers the transfer callback. Without this fix, the late callback raises `RuntimeError('Event loop is closed')` on the libusb callback thread and can abort the process. With this fix, the late callback is ignored.

# Root Cause

The libusb event thread schedules back onto the asyncio loop at seven sites. Before this fix, each site called `loop.call_soon_threadsafe(...)` directly, so a callback that arrived after loop close raised on the callback thread.

The fix adds `_safe_call_soon()` at `bumble/transport/usb.py:41`- `bumble/transport/usb.py:51`, which catches the closed-loop `RuntimeError` and turns late callbacks into no-ops. All libusb-event-thread scheduling sites now use it.
