### PR TITLE
Fix risk of accepting packets before firmware is loaded

### DIFF
--- a/bumble/drivers/intel.py
+++ b/bumble/drivers/intel.py
@@ -445,7 +445,6 @@ class Driver(common.Driver):
             )
 
     async def load_firmware(self) -> None:
-        self.host.ready = True
         device_info = await self.read_device_info()
         logger.debug(
             "device info: \n%s",
@@ -663,7 +662,6 @@ class Driver(common.Driver):
         await asyncio.sleep(_POST_RESET_DELAY)
 
     async def read_device_info(self) -> dict[ValueType, Any]:
-        self.host.ready = True
         response1 = await self.host.send_sync_command_raw(hci.HCI_Reset_Command())
         if not isinstance(
             response1.return_parameters, hci.HCI_StatusReturnParameters

--- a/bumble/drivers/rtk.py
+++ b/bumble/drivers/rtk.py
@@ -555,11 +555,9 @@ class Driver(common.Driver):
                 hci.HCI_Reset_Command(),
                 response_timeout=cls.POST_RESET_DELAY,
             )
-            host.ready = True  # Needed to let the host know the controller is ready.
         except asyncio.exceptions.TimeoutError:
             logger.warning("timeout waiting for hci reset, retrying")
             await host.send_sync_command(hci.HCI_Reset_Command())
-            host.ready = True
 
         response = await host.send_sync_command_raw(
             hci.HCI_Read_Local_Version_Information_Command()

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -31,6 +31,7 @@ from bumble.core import (
     InvalidStateError,
     PhysicalTransport,
 )
+from bumble.drivers.intel import HCI_INTEL_READ_VERSION_COMMAND
 from bumble.l2cap import L2CAP_PDU
 from bumble.snoop import Snooper
 from bumble.transport.common import TransportLostError
@@ -345,7 +346,8 @@ class Host(utils.EventEmitter):
         # Send a reset command unless a driver has already done so.
         if reset_needed:
             await self.send_sync_command(hci.HCI_Reset_Command())
-            self.ready = True
+        
+        self.ready = True
 
         response1 = await self.send_sync_command(
             hci.HCI_Read_Local_Supported_Commands_Command()
@@ -984,7 +986,10 @@ class Host(utils.EventEmitter):
 
         if self.ready or (
             isinstance(hci_packet, hci.HCI_Command_Complete_Event)
-            and hci_packet.command_opcode == hci.HCI_RESET_COMMAND
+            and (
+                hci_packet.command_opcode == hci.HCI_RESET_COMMAND
+                or hci_packet.command_opcode == HCI_INTEL_READ_VERSION_COMMAND
+            )
         ):
             self.on_hci_packet(hci_packet)
         else:

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -31,7 +31,6 @@ from bumble.core import (
     InvalidStateError,
     PhysicalTransport,
 )
-from bumble.drivers.intel import HCI_INTEL_READ_VERSION_COMMAND
 from bumble.l2cap import L2CAP_PDU
 from bumble.snoop import Snooper
 from bumble.transport.common import TransportLostError
@@ -988,7 +987,7 @@ class Host(utils.EventEmitter):
             isinstance(hci_packet, hci.HCI_Command_Complete_Event)
             and (
                 hci_packet.command_opcode == hci.HCI_RESET_COMMAND
-                or hci_packet.command_opcode == HCI_INTEL_READ_VERSION_COMMAND
+                or hci_packet.command_opcode >> 10 == hci.HCI_VENDOR_OGF
             )
         ):
             self.on_hci_packet(hci_packet)

--- a/bumble/host.py
+++ b/bumble/host.py
@@ -346,7 +346,7 @@ class Host(utils.EventEmitter):
         # Send a reset command unless a driver has already done so.
         if reset_needed:
             await self.send_sync_command(hci.HCI_Reset_Command())
-        
+
         self.ready = True
 
         response1 = await self.send_sync_command(


### PR DESCRIPTION
This PR fixes an error that occurs when a remote device repeatedly sends HCI_CONNECTION_REQUEST_COMMAND early while the local device still needs to load its firmware driver:

```
[2026-06-29 09:01:39.812] WARNING in host: HCI_ACCEPT_CONNECTION_REQUEST_COMMAND failed (UNKNOWN_CONNECTION_IDENTIFIER_ERROR)
Task exception was never retrieved
future: <Task finished name='Task-5' coro=<Host.send_async_command() done, defined at C:\Users\user\nxbt\.venv\Lib\site-packages\bumble\host.py:805> exception=HCI_Error()>
Traceback (most recent call last):
  File "C:\Users\user\nxbt\.venv\Lib\site-packages\bumble\host.py", line 829, in send_async_command
    raise hci.HCI_Error(status)
bumble.hci.HCI_Error: HCI_Error(hci/UNKNOWN_CONNECTION_IDENTIFIER_ERROR [0x2])
```

The root cause is that `Host.ready` was incorrectly set to True before the firmware driver had finished loading successfully.

In addition, I believe letting Drivers control `Host.ready` is risky, so this behavior has been consolidated and moved into `Host.reset` instead.
