### PR TITLE
fix: exclude channel 76 from default CS channel_map (Core Spec 6.0 compliance)

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -5442,7 +5442,7 @@ class Device(utils.CompositeEventEmitter):
         role: int = hci.CsRole.INITIATOR,
         rtt_type: int = hci.RttType.AA_ONLY,
         cs_sync_phy: int = hci.CsSyncPhy.LE_1M,
-        channel_map: bytes = b'\x54\x55\x55\x54\x55\x55\x55\x55\x55\x15',
+        channel_map: bytes = b'\x54\x55\x55\x54\x55\x55\x55\x55\x55\x05',
         channel_map_repetition: int = 0x01,
         channel_selection_type: int = hci.HCI_LE_CS_Create_Config_Command.ChannelSelectionType.ALGO_3B,
         ch3c_shape: int = hci.HCI_LE_CS_Create_Config_Command.Ch3cShape.HAT,

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -17,6 +17,7 @@
 # -----------------------------------------------------------------------------
 import asyncio
 import functools
+import inspect
 import logging
 import os
 from unittest import mock
@@ -691,6 +692,25 @@ async def test_power_on_default_static_address_should_not_be_any():
     await devices[0].power_on()
 
     assert devices[0].static_address != Address.ANY_RANDOM
+
+
+# -----------------------------------------------------------------------------
+def test_cs_channel_map_excludes_forbidden_channels():
+    forbidden = {0, 1, 23, 24, 25, 76, 77, 78, 79}
+    default_map = (
+        inspect.signature(Device.create_cs_config).parameters['channel_map'].default
+    )
+
+    enabled = {
+        byte_idx * 8 + bit
+        for byte_idx, byte in enumerate(default_map)
+        for bit in range(8)
+        if byte & (1 << bit)
+    }
+
+    assert enabled.isdisjoint(
+        forbidden
+    ), f"Default channel_map enables forbidden CS channels: {enabled & forbidden}"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #945

the default channel_map in Device.create_cs_config() had byte 9 set 
to 0x15 which enables channel 76. Core Spec 6.0 Vol 4 Part E §7.8.117 
requires channels 0,1,23,24,25,76,77,78 to be excluded from the CS 
Channel_Map. strict controllers (e.g. Nordic nRF54L15) correctly reject 
the command with UNSUPPORTED_FEATURE_OR_PARAMETER_VALUE_ERROR (0x11).

fix: change byte 9 from 0x15 to 0x05, keeping only channels 72 and 74 
enabled in that byte. same even-numbered channel pattern, now spec-compliant.

added a test verifying the default map has no overlap with the forbidden 
channel set.