### PR TITLE
Fix race condition in PeriodicAdvertisingSync state transition

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -913,7 +913,8 @@ class PeriodicAdvertisingSync(utils.EventEmitter):
             )
         )
 
-        self.state = self.State.PENDING
+        if self.state == self.State.INIT:
+            self.state = self.State.PENDING
 
     async def terminate(self) -> None:
         if self.state in (self.State.INIT, self.State.CANCELLED, self.State.TERMINATED):


### PR DESCRIPTION
In PeriodicAdvertisingSync.establish, the state was unconditionally set to PENDING after sending the create sync command. If the sync was established immediately (e.g. HCI_LE_PERIODIC_ADVERTISING_SYNC_ESTABLISHED_EVENT received before establish completed), the state transition to ESTABLISHED would be overwritten back to PENDING, causing timeouts in listeners waiting for establishment.

Only set state to PENDING if it is still INIT.

TAG=agy
CONV=e61bef8b-ae31-48da-9bac-74f55d92568d