### PR TITLE
transport/usb: Handle missing interruptEventHandler gracefully

### DIFF
--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -729,7 +729,10 @@ class UsbTransport(Transport):
         # We no longer need the event loop to run
         with self.lock:
             self.event_loop_should_exit = True
-        self.context.interruptEventHandler()
+        try:
+            self.context.interruptEventHandler()
+        except (AttributeError, usb1.USBError) as error:
+            logger.warning(f"Failed to interrupt event handler: {error}")
 
         self.device.releaseInterface(self.acl_interface.getNumber())
         if self.sco_interface:


### PR DESCRIPTION
Wrap `interruptEventHandler()` in a try-catch block to handle unsupported operations on older libusb versions.