### PR TITLE
Raise InvalidPacketError on a truncated ISO data packet

### DIFF
--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -8174,6 +8174,10 @@ class HCI_IsoDataPacket(HCI_Packet):
         packet_status_flag: int | None = None
 
         pos = 1
+        if len(packet) < pos + 4:
+            raise InvalidPacketError(
+                f'ISO data packet too short: {len(packet)} bytes'
+            )
         pdu_info, data_total_length = struct.unpack_from('<HH', packet, pos)
         connection_handle = pdu_info & 0xFFF
         pb_flag = (pdu_info >> 12) & 0b11
@@ -8186,10 +8190,14 @@ class HCI_IsoDataPacket(HCI_Packet):
         if ts_flag:
             if not should_include_sdu_info:
                 logger.warning(f'Timestamp included when pb_flag={bin(pb_flag)}')
+            if len(packet) < pos + 4:
+                raise InvalidPacketError('ISO data packet truncated (timestamp)')
             time_stamp, *_ = struct.unpack_from('<I', packet, pos)
             pos += 4
 
         if should_include_sdu_info:
+            if len(packet) < pos + 4:
+                raise InvalidPacketError('ISO data packet truncated (SDU info)')
             packet_sequence_number, sdu_info = struct.unpack_from('<HH', packet, pos)
             iso_sdu_length = sdu_info & 0xFFF
             packet_status_flag = (sdu_info >> 15) & 1

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -8174,6 +8174,8 @@ class HCI_IsoDataPacket(HCI_Packet):
         packet_status_flag: int | None = None
 
         pos = 1
+        if len(packet) < pos + 4:
+            raise InvalidPacketError(f'ISO data packet too short: {len(packet)} bytes')
         pdu_info, data_total_length = struct.unpack_from('<HH', packet, pos)
         connection_handle = pdu_info & 0xFFF
         pb_flag = (pdu_info >> 12) & 0b11
@@ -8186,10 +8188,14 @@ class HCI_IsoDataPacket(HCI_Packet):
         if ts_flag:
             if not should_include_sdu_info:
                 logger.warning(f'Timestamp included when pb_flag={bin(pb_flag)}')
+            if len(packet) < pos + 4:
+                raise InvalidPacketError('ISO data packet truncated (timestamp)')
             time_stamp, *_ = struct.unpack_from('<I', packet, pos)
             pos += 4
 
         if should_include_sdu_info:
+            if len(packet) < pos + 4:
+                raise InvalidPacketError('ISO data packet truncated (SDU info)')
             packet_sequence_number, sdu_info = struct.unpack_from('<HH', packet, pos)
             iso_sdu_length = sdu_info & 0xFFF
             packet_status_flag = (sdu_info >> 15) & 1

--- a/tests/hci_test.py
+++ b/tests/hci_test.py
@@ -702,6 +702,16 @@ def test_iso_data_packet():
 
 
 # -----------------------------------------------------------------------------
+def test_iso_data_packet_too_short():
+    # A truncated ISO data packet must raise InvalidPacketError, not the raw
+    # struct.error from unpack_from. Here pb_flag=0b00 asks for 4 bytes of SDU
+    # info at offset 5, but the packet ends at offset 5.
+    data = bytes.fromhex('0561000000')  # type + pdu_info(0x0061) + len(0) = 5 bytes
+    with pytest.raises(hci.InvalidPacketError):
+        hci.HCI_IsoDataPacket.from_bytes(data)
+
+
+# -----------------------------------------------------------------------------
 def run_test_events():
     test_HCI_Event()
     test_HCI_LE_Connection_Complete_Event()


### PR DESCRIPTION
Fixes #955.

`HCI_IsoDataPacket.from_bytes()` called `struct.unpack_from()` without first checking the buffer length, so a short packet surfaced the low-level `struct.error` instead of the `InvalidPacketError` the sibling `from_bytes()` parsers raise. A 5-byte ISO packet (`data_total_length=0`, `pb_flag=0b00`) reproduces it: the SDU-info read at offset 5 needs 4 bytes that are not present.

This guards each `unpack_from` with a length check and raises `InvalidPacketError`, matching `HCI_AclDataPacket.from_bytes()`.

Test: `tests/hci_test.py::test_iso_data_packet_too_short` (fails with `struct.error` before the change, passes after). Full `hci_test.py` suite green.