### PR TITLE
Don't mask BIG (sync) establishment failure with a KeyError

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -5229,7 +5229,11 @@ class Device(utils.CompositeEventEmitter):
                 )
                 await established
             except hci.HCI_Error:
-                del self.bigs[big_handle]
+                # The establishment-failure event handler may have already
+                # removed the entry; pop so this cleanup cannot raise KeyError
+                # and mask the HCI_Error (see on_big_termination for the same
+                # idempotent pattern).
+                self.bigs.pop(big_handle, None)
                 raise
 
         return big
@@ -5278,7 +5282,11 @@ class Device(utils.CompositeEventEmitter):
                 )
                 await established
             except hci.HCI_Error:
-                del self.big_syncs[big_handle]
+                # The establishment-failure event handler may have already
+                # removed the entry; pop so this cleanup cannot raise KeyError
+                # and mask the HCI_Error (see on_big_termination for the same
+                # idempotent pattern).
+                self.big_syncs.pop(big_handle, None)
                 raise
 
         return big_sync

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -30,6 +30,7 @@ from bumble.device import (
     Advertisement,
     AdvertisingEventProperties,
     AdvertisingParameters,
+    BigSyncParameters,
     CigParameters,
     CisLink,
     Connection,
@@ -879,6 +880,45 @@ async def test_get_remote_classic_features():
         await asyncio.wait_for(connection.get_remote_classic_features(), _TIMEOUT)
         == devices.controllers[1].lmp_features
     )
+
+
+# -----------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_create_big_sync_failure_propagates_hci_error():
+    # Regression: on a BIG sync establishment failure the event handler removes
+    # the big_syncs entry, and create_big_sync's except clause then removed it
+    # again with `del`, raising KeyError and masking the real HCI status.
+    device = Device(host=Host(None, None))
+    status = HCI_CONNECTION_FAILED_TO_BE_ESTABLISHED_ERROR
+
+    async def fake_send_async_command(command, check_status=True):
+        # The controller accepted the command; a failure event then arrives and
+        # its handler removes the entry before create_big_sync's except runs.
+        big_handle = next(iter(device.big_syncs))
+        asyncio.get_running_loop().call_soon(
+            device.on_big_sync_establishment,
+            status,
+            big_handle,
+            0,  # transport_latency_big
+            0,  # nse
+            0,  # bn
+            0,  # pto
+            0,  # irc
+            0,  # max_pdu
+            0,  # iso_interval
+            [],  # bis_handles
+        )
+        return HCI_SUCCESS
+
+    device.send_async_command = fake_send_async_command  # type: ignore[assignment]
+    pa_sync = mock.Mock(sync_handle=0)
+    parameters = BigSyncParameters(big_sync_timeout=1000, bis=[1])
+
+    with pytest.raises(HCI_Error) as exc_info:
+        await device.create_big_sync(pa_sync, parameters)
+
+    assert exc_info.value.error_code == status
+    assert device.big_syncs == {}
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #954.

On a BIG or BIG-sync establishment failure, the event handler (`on_big_establishment` / `on_big_sync_establishment`) removes the `bigs` / `big_syncs` entry and emits `ESTABLISHMENT_FAILURE`, which makes the awaited future raise `hci.HCI_Error`. `create_big()` / `create_big_sync()` then ran `del self.bigs[big_handle]` / `del self.big_syncs[big_handle]` in their `except hci.HCI_Error` clause on an entry that was already gone, raising `KeyError: 0` and discarding the real HCI status (e.g. a wrong broadcast code surfaces as `KeyError: 0` instead of `CONNECTION_TERMINATED_DUE_TO_MIC_FAILURE`).

This pops with a default instead of deleting, matching the idempotent pattern already used in `on_big_termination()`. The `HCI_Error` now propagates with its status intact.

Test: `tests/device_test.py::test_create_big_sync_failure_propagates_hci_error` reproduces the failure sequence (handler removes the entry, then the `except` clause runs); it raises `KeyError: 0` before the change and the correct `HCI_Error` after. Full `device_test.py` + `hci_test.py` suites green.