### PR TITLE
Revert "CIG: Fix CIG parameters for unidirectional CIS"

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1576,6 +1576,15 @@ class CigParameters:
         rtn_c_to_p: int = DEVICE_DEFAULT_ISO_CIS_RTN  # Number of C->P retransmissions
         rtn_p_to_c: int = DEVICE_DEFAULT_ISO_CIS_RTN  # Number of P->C retransmissions
 
+        def __post_init__(self) -> None:
+            # For unidirectional CIS (e.g., Central-to-Peripheral only), the unused direction's
+            # SDU size is 0. If SDU size is 0, we set RTN to 0 as well for maintaining
+            # compatibility with older firmware that has error 0x30 bug.
+            if self.max_sdu_c_to_p == 0:
+                self.rtn_c_to_p = 0
+            if self.max_sdu_p_to_c == 0:
+                self.rtn_p_to_c = 0
+
     cig_id: int
     cis_parameters: list[CisParameters]
     sdu_interval_c_to_p: int  # C->P SDU interval, in microseconds

--- a/bumble/device.py
+++ b/bumble/device.py
@@ -1576,18 +1576,6 @@ class CigParameters:
         rtn_c_to_p: int = DEVICE_DEFAULT_ISO_CIS_RTN  # Number of C->P retransmissions
         rtn_p_to_c: int = DEVICE_DEFAULT_ISO_CIS_RTN  # Number of P->C retransmissions
 
-        def __post_init__(self) -> None:
-            # For unidirectional CIS (e.g., Central-to-Peripheral only), the unused direction's
-            # SDU size is 0. If SDU size is 0, the corresponding retransmission count and PHY
-            # must also be set to 0. Otherwise, some controllers will reject the parameters
-            # with error 0x30 (Parameter Out Of Mandatory Range).
-            if self.max_sdu_c_to_p == 0:
-                self.rtn_c_to_p = 0
-                self.phy_c_to_p = hci.PhyBit(0)
-            if self.max_sdu_p_to_c == 0:
-                self.rtn_p_to_c = 0
-                self.phy_p_to_c = hci.PhyBit(0)
-
     cig_id: int
     cis_parameters: list[CisParameters]
     sdu_interval_c_to_p: int  # C->P SDU interval, in microseconds

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -597,6 +597,25 @@ async def test_cis_setup_failure():
 
 
 # -----------------------------------------------------------------------------
+def test_cis_parameters_unidirectional():
+    # Test C2P unidirectional (P to C not used)
+    cis_c2p = CigParameters.CisParameters(cis_id=1, max_sdu_p_to_c=0)
+    assert cis_c2p.max_sdu_c_to_p != 0
+    assert cis_c2p.rtn_c_to_p != 0
+    assert cis_c2p.phy_c_to_p != hci.PhyBit(0)
+    assert cis_c2p.rtn_p_to_c == 0
+    assert cis_c2p.phy_p_to_c != hci.PhyBit(0)
+
+    # Test P2C unidirectional (C to P not used)
+    cis_p2c = CigParameters.CisParameters(cis_id=2, max_sdu_c_to_p=0)
+    assert cis_p2c.max_sdu_p_to_c != 0
+    assert cis_p2c.rtn_p_to_c != 0
+    assert cis_p2c.phy_p_to_c != hci.PhyBit(0)
+    assert cis_p2c.rtn_c_to_p == 0
+    assert cis_p2c.phy_c_to_p != hci.PhyBit(0)
+
+
+# -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_enter_and_exit_sniff_mode():
     devices = TwoDevices()

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -597,25 +597,6 @@ async def test_cis_setup_failure():
 
 
 # -----------------------------------------------------------------------------
-def test_cis_parameters_unidirectional():
-    # Test C2P unidirectional (P to C not used)
-    cis_c2p = CigParameters.CisParameters(cis_id=1, max_sdu_p_to_c=0)
-    assert cis_c2p.max_sdu_c_to_p != 0
-    assert cis_c2p.rtn_c_to_p != 0
-    assert cis_c2p.phy_c_to_p != hci.PhyBit(0)
-    assert cis_c2p.rtn_p_to_c == 0
-    assert cis_c2p.phy_p_to_c == hci.PhyBit(0)
-
-    # Test P2C unidirectional (C to P not used)
-    cis_p2c = CigParameters.CisParameters(cis_id=2, max_sdu_c_to_p=0)
-    assert cis_p2c.max_sdu_p_to_c != 0
-    assert cis_p2c.rtn_p_to_c != 0
-    assert cis_p2c.phy_p_to_c != hci.PhyBit(0)
-    assert cis_p2c.rtn_c_to_p == 0
-    assert cis_p2c.phy_c_to_p == hci.PhyBit(0)
-
-
-# -----------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_enter_and_exit_sniff_mode():
     devices = TwoDevices()


### PR DESCRIPTION
Reverts google/bumble#943

which was trying to fix a HCI error `PARAMETER_OUT_OF_MANDATORY_RANGE_ERROR [0x30]` raised by a Bluetooth controller when receiving parameters from a CIS creation.

Based on the Spec about `LE Set CIG Parameters command`:

> The PHY_C_To_P[i] parameter identifies which PHY to use for transmission from the
Central to the Peripheral. **The Host shall set at least one bit in this parameter and the
Controller shall pick a PHY from the bits that are set.**

> The PHY_P_To_C[i] parameter identifies which PHY to use for transmission from the
Peripheral to the Central. The Host shall set at least one bit in this parameter and the
Controller shall pick a PHY from the bits that are set.

We should not assign 0 to PHY for any direction even if it's unidirectional CIS on the other direction.

> The RTN_C_To_P[i] (Retransmission Number) parameter contains the number of times
that a CIS Data PDU should be retransmitted from the Central to Peripheral before
being acknowledged or flushed (irrespective of which CIS events the retransmission
opportunities occur in). If the CIS is unidirectional from Peripheral to Central, this
parameter shall be ignored. Otherwise, this parameter is a recommendation to the
Controller which the Controller may ignore.
> 
> The RTN_P_To_C[i] parameter contains the number of times that a CIS Data PDU
should be retransmitted from the Peripheral to Central before being acknowledged or
flushed (irrespective of which CIS events the retransmission opportunities occur in). If
the CIS is unidirectional from Central to Peripheral, this parameter shall be ignored.
Otherwise, this parameter is a recommendation to the Controller which the Controller
may ignore.

This is ignored when it's unidirectional CIS on the other direction, but that specific controller doesn't satisfy if this is set to zero, but it also needs to set PHY to zero, which doesn't sound right and should file ticket to check with the vendor, instead of putting the wrong fix here.
