### PR TITLE
USB HCI transport teardown — `usbi_mutex` abort on close

### DIFF
--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -665,8 +665,6 @@ class UsbTransport(Transport):
         self.device = device
         self.acl_interface = acl_interface
         self.sco_interface = sco_interface
-        self.loop = asyncio.get_running_loop()
-        self.event_loop_done = self.loop.create_future()
         self.event_loop_should_exit = False
         self.lock = threading.Lock()
         self.closed = False
@@ -719,7 +717,6 @@ class UsbTransport(Transport):
                 logger.warning(f'!!! Exception while handling events: {error}')
 
         logger.debug('ending USB event loop')
-        _safe_call_soon(self.loop, self.event_loop_done.set_result, None)
 
     async def close(self):
         # close() may be reached both explicitly and through Transport.__aexit__.
@@ -747,8 +744,7 @@ class UsbTransport(Transport):
         # callback has returned. Wait and join before freeing transfers, the
         # device handle, or the context.
         logger.debug("waiting for USB event loop to be done...")
-        await self.event_loop_done
-        self.event_thread.join()
+        await asyncio.to_thread(self.event_thread.join)
         logger.debug("USB event loop done")
 
         self.device.releaseInterface(self.acl_interface.getNumber())

--- a/bumble/transport/usb.py
+++ b/bumble/transport/usb.py
@@ -414,10 +414,10 @@ class UsbPacketSink:
                 except usb1.USBError as error:
                     logger.debug(f'OUT transfer likely already completed ({error})')
 
-            try:
-                transfer.close()
-            except usb1.USBError as error:
-                logger.warning(f'failed to close transfer ({error})')
+        # Do not close the transfer objects here. The callbacks that wake this
+        # coroutine run on the libusb event thread and may not have returned yet.
+        # UsbTransport.close() stops and joins that thread before device.close()
+        # finalizes the transfers.
 
 
 READ_SIZE = 4096
@@ -669,6 +669,7 @@ class UsbTransport(Transport):
         self.event_loop_done = self.loop.create_future()
         self.event_loop_should_exit = False
         self.lock = threading.Lock()
+        self.closed = False
 
         # Get exclusive access
         device.claimInterface(acl_interface.getNumber())
@@ -721,6 +722,12 @@ class UsbTransport(Transport):
         _safe_call_soon(self.loop, self.event_loop_done.set_result, None)
 
     async def close(self):
+        # close() may be reached both explicitly and through Transport.__aexit__.
+        # Guard the native resources from a second teardown.
+        if self.closed:
+            return
+        self.closed = True
+
         self.source.close()
         self.sink.close()
         await self.source.terminate()
@@ -734,16 +741,21 @@ class UsbTransport(Transport):
         except (AttributeError, usb1.USBError) as error:
             logger.warning(f"Failed to interrupt event handler: {error}")
 
+        # handleEvents() owns libusb state until the event thread has returned.
+        # In particular, transfer cancellation callbacks only schedule their
+        # asyncio completion signals; those signals do not prove that the native
+        # callback has returned. Wait and join before freeing transfers, the
+        # device handle, or the context.
+        logger.debug("waiting for USB event loop to be done...")
+        await self.event_loop_done
+        self.event_thread.join()
+        logger.debug("USB event loop done")
+
         self.device.releaseInterface(self.acl_interface.getNumber())
         if self.sco_interface:
             self.device.releaseInterface(self.sco_interface.getNumber())
         self.device.close()
         self.context.close()
-
-        # Wait for the thread to terminate
-        logger.debug("waiting for USB event loop to be done...")
-        await self.event_loop_done
-        logger.debug("USB event loop done")
 
 
 async def open_usb_transport(spec: str) -> Transport:


### PR DESCRIPTION
Closing the USB HCI transport (a Nordic nRF52840 Zephyr dongle, `usb:2fe3:000b`) aborts 

`UsbPacketSink.terminate()` cancels its OUT transfer but reaps it via a shared semaphore
that a prior completion can pre-release, so a cancellation may go unreaped; and the transfer objects are
freed implicitly by python-libusb1's `USBDeviceHandle.close()` rather than explicitly after the join.
`libusb_free_transfer()` on a still-active transfer is illegal and destroys its mutex mid-use

## Reproduce

Run repeated BLE sessions over the nRF USB HCI transport and close each; the abort fires at teardown
(exit 134 + the `usbi_mutex` assertions), including on runs where the BLE work fully succeeded. It is
timing/load dependent in *severity* but reproduces readily under back-to-back cycles.