### PR TITLE
smp: wait for key distribution to be flushed before completing pairing

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -2097,6 +2097,21 @@ class Connection(utils.CompositeEventEmitter):
     def data_packet_queue(self) -> DataPacketQueue | None:
         return self.device.host.get_data_packet_queue(self.handle)
 
+    async def drain(self) -> None:
+        """Wait until the controller has completed every data packet queued for
+        this connection.
+
+        Returns immediately if this connection has no packet queue, or if
+        nothing has ever been queued for it.
+        """
+        if (data_packet_queue := self.data_packet_queue) is None:
+            return
+        try:
+            await data_packet_queue.drain(self.handle)
+        except ValueError:
+            # Nothing was ever sent on this connection.
+            pass
+
     def cancel_on_disconnection(self, awaitable: Awaitable[_T]) -> Awaitable[_T]:
         """
         Helper method to call `utils.cancel_on_event` for the 'disconnection' event

--- a/bumble/smp.py
+++ b/bumble/smp.py
@@ -1304,6 +1304,13 @@ class Session:
 
         self.completed = True
 
+        # The keys we have just distributed may still be waiting for the
+        # controller's flow control. Don't report success until they have all
+        # been acknowledged: an application that disconnects as soon as
+        # `pair()` returns would otherwise cut the last key distribution PDU,
+        # and a peer that never receives it discards the incomplete bond.
+        await self.connection.drain()
+
         if self.pairing_result is not None and not self.pairing_result.done():
             self.pairing_result.set_result(None)
 

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -363,6 +363,48 @@ async def test_self_smp(io_caps, sc, mitm, key_dist):
 
 # -----------------------------------------------------------------------------
 @pytest.mark.asyncio
+async def test_self_smp_waits_for_key_distribution():
+    two_devices = await TwoDevices.create_with_connection()
+    for device in two_devices.devices:
+        device.pairing_config_factory = lambda _: PairingConfig(
+            delegate=PairingDelegate(PairingDelegate.IoCapability.NO_OUTPUT_NO_INPUT)
+        )
+
+    connection = two_devices.connections[0]
+    packet_queue = connection.data_packet_queue
+    assert packet_queue is not None
+
+    # Withhold the controller's packet completions, so that everything the
+    # initiator sends stays in flight.
+    withheld: list[tuple[int, int]] = []
+    complete_packets = packet_queue.on_packets_completed
+    packet_queue.on_packets_completed = lambda count, handle: withheld.append(
+        (count, handle)
+    )
+
+    pairing = asyncio.create_task(connection.pair())
+    for _ in range(100):
+        if connection.is_encrypted:
+            break
+        await asyncio.sleep(0.01)
+    await async_barrier()
+
+    # Check that the withholding is in effect, then that pairing has not been
+    # reported as complete while the keys may still be sitting in the queue.
+    assert connection.is_encrypted
+    assert packet_queue.pending > 0
+    assert not pairing.done()
+
+    # Complete the packets: pairing may now finish.
+    packet_queue.on_packets_completed = complete_packets
+    for count, handle in withheld:
+        complete_packets(count, handle)
+    await asyncio.wait_for(pairing, timeout=5.0)
+    assert packet_queue.pending == 0
+
+
+# -----------------------------------------------------------------------------
+@pytest.mark.asyncio
 async def test_self_smp_reject():
     class RejectingDelegate(PairingDelegate):
         def __init__(self):


### PR DESCRIPTION
## Problem

`Session.pair()` resolves as soon as the pairing procedure is done, which happens before the key distribution PDUs the initiator has just queued have been acknowledged by the controller. `distribute_keys()` only enqueues them into the connection's `DataPacketQueue`, and `Session.on_pairing()` sets `pairing_result` right after. An application that disconnects as soon as `await connection.pair()` returns therefore races its own last key PDU, and `Connection.__aexit__` does exactly that.

Observed on a bench with an external LE Audio controller and a Zephyr 4.4 broadcast sink (SC + MITM, the sink asking for the initiator's IRK only and distributing nothing itself). Peer-side SMP trace:

```
smp_pairing_req: req: io_capability 0x03, auth_req 0x0D, init_key_dist 0x03, resp_key_dist 0x03
smp_pairing_req: rsp: io_capability 0x03, auth_req 0x09, init_key_dist 0x02, resp_key_dist 0x00
bt_smp_encrypt_change: encrypt 0x01 hci status 0x00
smp_ident_info:                       <- Identity Information (0x08)
... 30 ms gap ...
bt_smp_disconnected
smp_pairing_complete: got status 0x8
bt_keys_clear: ...
Disconnected: reason 0x13
```

Identity Address Information (0x09) never arrives, so the peer reports pairing status 0x08 and clears the half distributed key, while the initiator keeps its LTK and prints success. Every later connection then fails to encrypt with `PIN_OR_KEY_MISSING`.

`run_pair` in `apps/auracast.py` hits this on every run. `apps/pair.py` avoids the same race today only by sleeping `POST_PAIRING_DELAY` before disconnecting.

## Change

- `Connection.drain()`, mirroring the existing `_IsoLink.drain()`, so a caller can wait for the controller to complete what was queued for a connection.
- `Session.on_pairing()` awaits it before resolving `pairing_result`. When the queue is already drained the event is set, so the await does not yield and adds no latency to the common path.

## Testing

- New `tests/self_test.py::test_self_smp_waits_for_key_distribution` withholds the controller's packet completions, asserts the packets really are still in flight, and asserts that pairing is not reported as complete until they are acknowledged. It fails on main and passes with this change.
- `pytest tests`: 934 passed, 1 skipped, 6 failed. The 6 failures are in `tests/transport_test.py::test_open_transport_with_metadata` (android-netsim spec parsing) and fail identically on unmodified main.
- `black -S --check`, `ruff check` and `mypy` clean on the touched files.
- The hardware scenario above has not been re-run against the patched host yet, so the confirmation here is the unit test plus the peer-side trace that identified the race.
