### PR TITLE
Make sdp.Server.Service a type alias

### DIFF
--- a/bumble/device.py
+++ b/bumble/device.py
@@ -2644,11 +2644,13 @@ class Device(utils.CompositeEventEmitter):
             host.link_key_provider = self.get_link_key
 
     @property
-    def sdp_service_records(self):
+    def sdp_service_records(self) -> dict[int, sdp.Server.Service]:
         return self.sdp_server.service_records
 
     @sdp_service_records.setter
-    def sdp_service_records(self, service_records):
+    def sdp_service_records(
+        self, service_records: dict[int, sdp.Server.Service]
+    ) -> None:
         self.sdp_server.service_records = service_records
 
     def lookup_connection(self, connection_handle: int) -> Connection | None:

--- a/bumble/sdp.py
+++ b/bumble/sdp.py
@@ -22,7 +22,7 @@ import logging
 import struct
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, ClassVar, NewType, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, TypeVar
 
 from typing_extensions import Self
 
@@ -1076,7 +1076,7 @@ class Client:
 class Server:
     CONTINUATION_STATE = bytes([0x01, 0x00])
     channel: l2cap.ClassicChannel | None
-    Service = NewType('Service', list[ServiceAttribute])
+    Service: TypeAlias = list[ServiceAttribute]
     service_records: dict[int, Service]
     current_response: None | bytes | tuple[int, list[int]]
 


### PR DESCRIPTION
In my project, I must construct service records by hand and hit the following typing error in the process:

```python
device.sdp_service_records = {
    handle: rfcomm.make_service_sdp_records(handle, channel, core.UUID(uuid))
    for uuid, handle in _SDP_SERVICE_HANDLES.items()
}
```

```
classic.py:536: error: Value expression in dictionary comprehension has incompatible type
"list[ServiceAttribute]"; expected type "Service"  [misc]
```

`sdp.Server.Service` is a `NewType` over `list[ServiceAttribute]`, and a `NewType` is satisfied only by an explicit constructor call. `Device.sdp_service_records` is unannotated for that reason: annotating it with the `NewType` in-place causes mypy errors:

```
apps/rfcomm_bridge.py:112: error: Dict entry 0 has incompatible type
"int": "list[ServiceAttribute]"; expected "int": "Service"
```

I suggest to fix it as follows as the alternative to keep the nominal type and change every producer to return `Server.Service` breaks every downstream user who assigns a list they built themselves:

Make `Service` a type alias and give `Device.sdp_service_records` the annotation the `NewType` ruled out: `sdp_records()` helpers are already annotated with `dict[int, list[ServiceAttribute]]` by hand.