### PR TITLE
fix: In HFP change roam indicator from CALL to ROAM

### DIFF
--- a/bumble/hfp.py
+++ b/bumble/hfp.py
@@ -602,7 +602,7 @@ class AgIndicatorState:
     def roam(cls: type[Self]) -> Self:
         """Default roam indicator state."""
         return cls(
-            indicator=AgIndicator.CALL, supported_values={0, 1}, current_status=0
+            indicator=AgIndicator.ROAM, supported_values={0, 1}, current_status=0
         )
 
     @classmethod


### PR DESCRIPTION
Fix in HandsFreeProfile (HFP): 
The AgIndicator is erroneously set to `CALL` for the roam function. This small patch sets it to `ROAM` instead.