### PR TITLE
Feature - add <Coordinated Set Name> characteristic to csip.py

### DIFF
--- a/bumble/gatt.py
+++ b/bumble/gatt.py
@@ -205,6 +205,7 @@ GATT_SET_IDENTITY_RESOLVING_KEY_CHARACTERISTIC  = UUID.from_16_bits(0x2B84, 'Set
 GATT_COORDINATED_SET_SIZE_CHARACTERISTIC        = UUID.from_16_bits(0x2B85, 'Coordinated Set Size')
 GATT_SET_MEMBER_LOCK_CHARACTERISTIC             = UUID.from_16_bits(0x2B86, 'Set Member Lock')
 GATT_SET_MEMBER_RANK_CHARACTERISTIC             = UUID.from_16_bits(0x2B87, 'Set Member Rank')
+GATT_COORDINATED_SET_NAME_CHARACTERISTIC        = UUID.from_16_bits(0x2C1A, 'Coordinated Set Name')
 
 # Media Control Service (MCS)
 GATT_MEDIA_PLAYER_NAME_CHARACTERISTIC                     = UUID.from_16_bits(0x2B93, 'Media Player Name')

--- a/bumble/profiles/csip.py
+++ b/bumble/profiles/csip.py
@@ -27,6 +27,7 @@ from bumble import core, crypto, device, gatt, gatt_client
 # Constants
 # -----------------------------------------------------------------------------
 SET_IDENTITY_RESOLVING_KEY_LENGTH = 16
+COORDINATED_SET_NAME_MAX_LENGTH = 128
 
 
 class SirkType(enum.IntEnum):
@@ -160,12 +161,18 @@ class CoordinatedSetIdentificationService(gatt.TemplateService):
             characteristics.append(self.set_member_rank_characteristic)
 
         if coordinated_set_name is not None:
+            name_bytes = coordinated_set_name.encode('utf-8')
+            if len(name_bytes) > COORDINATED_SET_NAME_MAX_LENGTH:
+                raise core.InvalidArgumentError(
+                    f'Coordinated Set Name is {len(name_bytes)} octets, '
+                    f'maximum is {COORDINATED_SET_NAME_MAX_LENGTH}'
+                )
             self.coordinated_set_name_characteristic = gatt.Characteristic(
                 uuid=gatt.GATT_COORDINATED_SET_NAME_CHARACTERISTIC,
                 properties=gatt.Characteristic.Properties.READ
                 | gatt.Characteristic.Properties.NOTIFY,
                 permissions=gatt.Characteristic.Permissions.READ_REQUIRES_ENCRYPTION,
-                value=coordinated_set_name.encode('utf-8'),
+                value=name_bytes,
             )
             characteristics.append(self.coordinated_set_name_characteristic)
 

--- a/bumble/profiles/csip.py
+++ b/bumble/profiles/csip.py
@@ -22,6 +22,7 @@ import enum
 import struct
 
 from bumble import core, crypto, device, gatt, gatt_client
+from bumble.gatt_adapters import UTF8CharacteristicProxyAdapter
 
 # -----------------------------------------------------------------------------
 # Constants
@@ -219,7 +220,7 @@ class CoordinatedSetIdentificationProxy(gatt_client.ProfileServiceProxy):
     coordinated_set_size: gatt_client.CharacteristicProxy[bytes] | None = None
     set_member_lock: gatt_client.CharacteristicProxy[bytes] | None = None
     set_member_rank: gatt_client.CharacteristicProxy[bytes] | None = None
-    coordinated_set_name: gatt_client.CharacteristicProxy[bytes] | None = None
+    coordinated_set_name: UTF8CharacteristicProxyAdapter | None = None
 
     def __init__(self, service_proxy: gatt_client.ServiceProxy) -> None:
         self.service_proxy = service_proxy
@@ -246,7 +247,9 @@ class CoordinatedSetIdentificationProxy(gatt_client.ProfileServiceProxy):
         if characteristics := service_proxy.get_characteristics_by_uuid(
             gatt.GATT_COORDINATED_SET_NAME_CHARACTERISTIC
         ):
-            self.coordinated_set_name = characteristics[0]
+            self.coordinated_set_name = UTF8CharacteristicProxyAdapter(
+                characteristics[0]
+            )
 
     async def read_set_identity_resolving_key(self) -> tuple[SirkType, bytes]:
         '''Reads SIRK and decrypts if encrypted.'''

--- a/bumble/profiles/csip.py
+++ b/bumble/profiles/csip.py
@@ -98,6 +98,7 @@ class CoordinatedSetIdentificationService(gatt.TemplateService):
     coordinated_set_size_characteristic: gatt.Characteristic[bytes] | None = None
     set_member_lock_characteristic: gatt.Characteristic[bytes] | None = None
     set_member_rank_characteristic: gatt.Characteristic[bytes] | None = None
+    coordinated_set_name_characteristic: gatt.Characteristic[bytes] | None = None
 
     def __init__(
         self,
@@ -106,6 +107,7 @@ class CoordinatedSetIdentificationService(gatt.TemplateService):
         coordinated_set_size: int | None = None,
         set_member_lock: MemberLock | None = None,
         set_member_rank: int | None = None,
+        coordinated_set_name: str | None = None,
     ) -> None:
         if len(set_identity_resolving_key) != SET_IDENTITY_RESOLVING_KEY_LENGTH:
             raise core.InvalidArgumentError(
@@ -157,6 +159,16 @@ class CoordinatedSetIdentificationService(gatt.TemplateService):
             )
             characteristics.append(self.set_member_rank_characteristic)
 
+        if coordinated_set_name is not None:
+            self.coordinated_set_name_characteristic = gatt.Characteristic(
+                uuid=gatt.GATT_COORDINATED_SET_NAME_CHARACTERISTIC,
+                properties=gatt.Characteristic.Properties.READ
+                | gatt.Characteristic.Properties.NOTIFY,
+                permissions=gatt.Characteristic.Permissions.READ_REQUIRES_ENCRYPTION,
+                value=coordinated_set_name.encode('utf-8'),
+            )
+            characteristics.append(self.coordinated_set_name_characteristic)
+
         super().__init__(characteristics)
 
     async def on_sirk_read(self, connection: device.Connection) -> bytes:
@@ -200,6 +212,7 @@ class CoordinatedSetIdentificationProxy(gatt_client.ProfileServiceProxy):
     coordinated_set_size: gatt_client.CharacteristicProxy[bytes] | None = None
     set_member_lock: gatt_client.CharacteristicProxy[bytes] | None = None
     set_member_rank: gatt_client.CharacteristicProxy[bytes] | None = None
+    coordinated_set_name: gatt_client.CharacteristicProxy[bytes] | None = None
 
     def __init__(self, service_proxy: gatt_client.ServiceProxy) -> None:
         self.service_proxy = service_proxy
@@ -222,6 +235,11 @@ class CoordinatedSetIdentificationProxy(gatt_client.ProfileServiceProxy):
             gatt.GATT_SET_MEMBER_RANK_CHARACTERISTIC
         ):
             self.set_member_rank = characteristics[0]
+
+        if characteristics := service_proxy.get_characteristics_by_uuid(
+            gatt.GATT_COORDINATED_SET_NAME_CHARACTERISTIC
+        ):
+            self.coordinated_set_name = characteristics[0]
 
     async def read_set_identity_resolving_key(self) -> tuple[SirkType, bytes]:
         '''Reads SIRK and decrypts if encrypted.'''

--- a/tests/csip_test.py
+++ b/tests/csip_test.py
@@ -140,8 +140,8 @@ async def test_coordinated_set_name():
 
     # Verify the optional Coordinated Set Name characteristic is present and readable.
     assert csis_client.coordinated_set_name is not None
-    name_bytes = await csis_client.coordinated_set_name.read_value()
-    assert name_bytes.decode('utf-8') == SET_NAME
+    name = await csis_client.coordinated_set_name.read_value()
+    assert name == SET_NAME
 
 
 # -----------------------------------------------------------------------------

--- a/tests/csip_test.py
+++ b/tests/csip_test.py
@@ -110,6 +110,73 @@ async def test_csis(sirk_type):
 
 
 # -----------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_coordinated_set_name():
+    SIRK = bytes.fromhex('2f62c8ae41867d1bb619e788a2605faa')
+    LTK = bytes.fromhex('2f62c8ae41867d1bb619e788a2605faa')
+    SET_NAME = 'My Earbuds'
+
+    devices = TwoDevices()
+    devices[0].add_service(
+        csip.CoordinatedSetIdentificationService(
+            set_identity_resolving_key=SIRK,
+            set_identity_resolving_key_type=csip.SirkType.PLAINTEXT,
+            coordinated_set_name=SET_NAME,
+        )
+    )
+
+    await devices.setup_connection()
+
+    # Mock encryption.
+    devices.connections[0].encryption = 1
+    devices.connections[1].encryption = 1
+    devices[0].get_long_term_key = mock.AsyncMock(return_value=LTK)
+    devices[1].get_long_term_key = mock.AsyncMock(return_value=LTK)
+
+    peer = device.Peer(devices.connections[1])
+    csis_client = await peer.discover_service_and_create_proxy(
+        csip.CoordinatedSetIdentificationProxy
+    )
+
+    # Verify the optional Coordinated Set Name characteristic is present and readable.
+    assert csis_client.coordinated_set_name is not None
+    name_bytes = await csis_client.coordinated_set_name.read_value()
+    assert name_bytes.decode('utf-8') == SET_NAME
+
+
+# -----------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_coordinated_set_name_optional():
+    '''Coordinated Set Name is optional: omitting it should leave the proxy attribute as None.'''
+    SIRK = bytes.fromhex('2f62c8ae41867d1bb619e788a2605faa')
+    LTK = bytes.fromhex('2f62c8ae41867d1bb619e788a2605faa')
+
+    devices = TwoDevices()
+    devices[0].add_service(
+        csip.CoordinatedSetIdentificationService(
+            set_identity_resolving_key=SIRK,
+            set_identity_resolving_key_type=csip.SirkType.PLAINTEXT,
+        )
+    )
+
+    await devices.setup_connection()
+
+    # Mock encryption.
+    devices.connections[0].encryption = 1
+    devices.connections[1].encryption = 1
+    devices[0].get_long_term_key = mock.AsyncMock(return_value=LTK)
+    devices[1].get_long_term_key = mock.AsyncMock(return_value=LTK)
+
+    peer = device.Peer(devices.connections[1])
+    csis_client = await peer.discover_service_and_create_proxy(
+        csip.CoordinatedSetIdentificationProxy
+    )
+
+    # Coordinated Set Name was not provided, so the proxy attribute should be None.
+    assert csis_client.coordinated_set_name is None
+
+
+# -----------------------------------------------------------------------------
 async def run():
     test_sih()
     await test_csis()

--- a/tests/csip_test.py
+++ b/tests/csip_test.py
@@ -23,7 +23,7 @@ from unittest import mock
 
 import pytest
 
-from bumble import device
+from bumble import core, device
 from bumble.profiles import csip
 from bumble.testing.test_utils import TwoDevices
 
@@ -174,6 +174,29 @@ async def test_coordinated_set_name_optional():
 
     # Coordinated Set Name was not provided, so the proxy attribute should be None.
     assert csis_client.coordinated_set_name is None
+
+
+# -----------------------------------------------------------------------------
+def test_coordinated_set_name_max_length():
+    '''Coordinated Set Name is limited to 128 octets as UTF-8.'''
+    SIRK = bytes.fromhex('2f62c8ae41867d1bb619e788a2605faa')
+
+    # A 128-character ASCII string encodes to exactly 128 octets (within limit).
+    valid_name = 'a' * 128
+    service = csip.CoordinatedSetIdentificationService(
+        set_identity_resolving_key=SIRK,
+        set_identity_resolving_key_type=csip.SirkType.PLAINTEXT,
+        coordinated_set_name=valid_name,
+    )
+    assert service.coordinated_set_name_characteristic is not None
+
+    # A 129-character ASCII string encodes to 129 octets (over the limit).
+    with pytest.raises(core.InvalidArgumentError):
+        csip.CoordinatedSetIdentificationService(
+            set_identity_resolving_key=SIRK,
+            set_identity_resolving_key_type=csip.SirkType.PLAINTEXT,
+            coordinated_set_name='a' * 129,
+        )
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Recently, the Bluetooth SIG adopted CSIS (Coordinated Set  Identification Service) v1.1, which introduces a
 new optional characteristic: Coordinated Set Name  (UUID 0x2C1A). This PR adds the <Coordindated Set Name> characteristic to `csip,py`. Moreover,  tests have been added in `test_csip.py `
 
 According to Spec.:

>  The Coordinated Set Name characteristic shall be the name of the Coordinated Set. The characteristic value is a UTF-8 string represented by a minimum of 0 octets and a maximum of 128 octets.